### PR TITLE
Enable TLS1.2 in download_file

### DIFF
--- a/coriolis/wsman.py
+++ b/coriolis/wsman.py
@@ -95,6 +95,8 @@ class WSManConnection(object):
         # Nano Server does not have Invoke-WebRequest and additionally
         # this is also faster
         self.exec_ps_command(
+            "[Net.ServicePointManager]::SecurityProtocol = "
+            "[Net.SecurityProtocolType]::Tls12;"
             "if(!([System.Management.Automation.PSTypeName]'"
             "System.Net.Http.HttpClient').Type) {$assembly = "
             "[System.Reflection.Assembly]::LoadWithPartialName("


### PR DESCRIPTION
TLS 1.0 is broken and a lot of servers have disabled it. This sets TLS 1.2 in powershell before calling download.