### PR TITLE
Skip checking reservations on missing `reservation_id`

### DIFF
--- a/coriolis/conductor/rpc/server.py
+++ b/coriolis/conductor/rpc/server.py
@@ -140,7 +140,11 @@ class ConductorServerEndpoint(object):
             LOG.debug(
                 "Attempting to check reservation with ID '%s' for transfer "
                 "action '%s'", reservation_id, action_id)
-        self._licensing_client.check_reservation(reservation_id)
+            self._licensing_client.check_reservation(reservation_id)
+        else:
+            LOG.debug(
+                "Transfer action '%s' has no reservation ID set. Skipping "
+                "all reservation licensing checks.", action_id)
 
     def create_endpoint(self, ctxt, name, endpoint_type, description,
                         connection_info):


### PR DESCRIPTION
In case of Replicas which did not have a Reservation ID created for
them, skip the reservation check.