### PR TITLE
Ensure disk ordering is preserved during Replication.

### DIFF
--- a/coriolis/schemas.py
+++ b/coriolis/schemas.py
@@ -10,6 +10,8 @@ import jsonschema
 from oslo_log import log as logging
 
 from coriolis import exception
+from coriolis import utils 
+
 
 LOG = logging.getLogger(__name__)
 
@@ -32,6 +34,10 @@ _CORIOLIS_NETWORK_MAP_SCHEMA_NAME = "network_map_schema.json"
 _CORIOLIS_STORAGE_MAPPINGS_SCHEMA_NAME = "storage_mappings_schema.json"
 _CORIOLIS_VM_STORAGE_SCHEMA_NAME = "vm_storage_schema.json"
 _CORIOLIS_VOLUMES_INFO_SCHEMA_NAME = "volumes_info_schema.json"
+_CORIOLIS_DISK_SYNC_RESOURCES_INFO_SCHEMA_NAME = (
+    "disk_sync_resources_info_schema.json")
+_CORIOLIS_DISK_SYNC_RESOURCES_CONN_INFO_SCHEMA_NAME = (
+    "disk_sync_resources_conn_info_schema.json")
 
 
 def get_schema(package_name, schema_name,
@@ -52,16 +58,26 @@ def get_schema(package_name, schema_name,
     return schema
 
 
-def validate_value(val, schema, format_checker=None):
+def validate_value(val, schema, format_checker=None, raise_on_error=True):
     """Simple wrapper for jsonschema.validate for usability.
-
     NOTE: silently passes empty schemas.
+
+    If `raise_on_error` is False, returns a boolean indicating whether
+    or not the validation was successful.
     """
     try:
         jsonschema.validate(val, schema, format_checker=format_checker)
     except jsonschema.exceptions.ValidationError as ex:
-        raise exception.SchemaValidationException(
-            "Schema validation failed: %s" % str(ex))
+        if raise_on_error:
+            raise exception.SchemaValidationException(
+                "Schema validation failed: %s" % str(ex))
+        else:
+            LOG.warn(
+                "Schema validation failed, ignoring: %s",
+                utils.get_exception_details())
+        return False
+
+    return True
 
 
 def validate_string(json_string, schema):
@@ -106,3 +122,9 @@ CORIOLIS_VM_STORAGE_SCHEMA = get_schema(
 
 CORIOLIS_VOLUMES_INFO_SCHEMA = get_schema(
     __name__, _CORIOLIS_VOLUMES_INFO_SCHEMA_NAME)
+
+CORIOLIS_DISK_SYNC_RESOURCES_INFO_SCHEMA = get_schema(
+    __name__, _CORIOLIS_DISK_SYNC_RESOURCES_INFO_SCHEMA_NAME)
+
+CORIOLIS_DISK_SYNC_RESOURCES_CONN_INFO_SCHEMA = get_schema(
+    __name__, _CORIOLIS_DISK_SYNC_RESOURCES_CONN_INFO_SCHEMA_NAME)

--- a/coriolis/schemas.py
+++ b/coriolis/schemas.py
@@ -31,6 +31,7 @@ _CORIOLIS_SOURCE_OPTIONS_SCHEMA_NAME = "source_options_schema.json"
 _CORIOLIS_NETWORK_MAP_SCHEMA_NAME = "network_map_schema.json"
 _CORIOLIS_STORAGE_MAPPINGS_SCHEMA_NAME = "storage_mappings_schema.json"
 _CORIOLIS_VM_STORAGE_SCHEMA_NAME = "vm_storage_schema.json"
+_CORIOLIS_VOLUMES_INFO_SCHEMA_NAME = "volumes_info_schema.json"
 
 
 def get_schema(package_name, schema_name,
@@ -102,3 +103,6 @@ CORIOLIS_STORAGE_MAPPINGS_SCHEMA = get_schema(
 
 CORIOLIS_VM_STORAGE_SCHEMA = get_schema(
     __name__, _CORIOLIS_VM_STORAGE_SCHEMA_NAME)
+
+CORIOLIS_VOLUMES_INFO_SCHEMA = get_schema(
+    __name__, _CORIOLIS_VOLUMES_INFO_SCHEMA_NAME)

--- a/coriolis/schemas/disk_sync_resources_conn_info_schema.json
+++ b/coriolis/schemas/disk_sync_resources_conn_info_schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://cloudbase.it/coriolis/schemas/disk_sync_resources_conn_info#",
+  "type": "object",
+  "description": "Object defining SSH connection parameters for a temporary minion VM which will carry out disk syncing and/or Linux OSMorphing",
+  "properties": {
+    "ip": {
+      "type": "string"
+    },
+    "port": {
+      "type": "integer"
+    },
+    "username": {
+      "type": "string"
+    },
+    "password": {
+      "$ref": "#/definitions/nullableString"
+    },
+    "pkey": {
+      "$ref": "#/definitions/nullableString"
+    },
+    "cert_pem": {
+      "type": "string"
+    },
+    "cert_key_pem": {
+      "type": "string"
+    }
+  },
+  "required": ["ip", "port", "username"],
+  "definitions": {
+    "nullableString": {
+      "oneOf": [{
+        "type": "string"
+      }, {
+        "type": "null"
+      }]
+    }
+  }
+}

--- a/coriolis/schemas/disk_sync_resources_info_schema.json
+++ b/coriolis/schemas/disk_sync_resources_info_schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://cloudbase.it/coriolis/schemas/disk_sync_resources_info#",
+  "type": "object",
+  "description": "Information returned after the 'DEPLOY_REPLICA_TARGET_RESOURCES' task and passed to 'REPLICATE_DISKS', as well as for 'DEPLOY_DISK_COPY_RESOURCES' and 'COPY_DISKS_DATA'. The only required property is the 'volumes_info', and the provider plugins may freely declare and use any other fields.",
+  "properties": {
+    "volumes_info": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "Object with information on the replicated volumes. Provider plugins may add their fields as required.",
+        "properties": {
+          "disk_id": {
+            "type": "string",
+            "description": "String ID of the source disk the replicated volume corresponds to."
+          },
+          "volume_dev": {
+            "type": "string",
+            "description": "String device path (ex: /dev/sdc) from within the temporary minion VM where the disk was attached."
+          }
+        },
+        "required": ["disk_id", "volume_dev"],
+        "additionalProperties": true
+      }
+    }
+  },
+  "required": ["volumes_info"],
+  "additionalProperties": true
+}

--- a/coriolis/schemas/os_morphing_resources_schema.json
+++ b/coriolis/schemas/os_morphing_resources_schema.json
@@ -27,7 +27,7 @@
           "type": "string"
         }
       },
-      "required": ["ip", "port"]
+      "required": ["ip", "port", "username"]
     },
     "osmorphing_info": {
       "type": "object",

--- a/coriolis/schemas/os_morphing_resources_schema.json
+++ b/coriolis/schemas/os_morphing_resources_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://cloudbase.it/coriolis/schemas/import_info#",
+  "$schema": "http://cloudbase.it/coriolis/schemas/osmorphing_resources#",
   "type": "object",
   "properties": {
     "osmorphing_connection_info": {

--- a/coriolis/schemas/vm_export_info_schema.json
+++ b/coriolis/schemas/vm_export_info_schema.json
@@ -76,7 +76,7 @@
             "type": "object",
             "properties": {
               "id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               },
               "format": {
                 "type": "string",
@@ -92,7 +92,7 @@
                 "type": "string"
               },
               "controller_id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               },
               "storage_backend_identifier": {
                 "type": "string",
@@ -118,13 +118,13 @@
             "type": "object",
             "properties": {
               "id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               },
               "unit_number": {
                 "$ref": "#/definitions/numberOrString"
               },
               "controller_id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               }
             },
             "required": [
@@ -157,7 +157,7 @@
                 "type": "integer"
               },
               "id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               },
               "mac_address": {
                 "$ref": "#/definitions/nullableString"
@@ -179,7 +179,7 @@
             "type": "object",
             "properties": {
               "id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               }
             }
           },
@@ -194,13 +194,13 @@
             "type": "object",
             "properties": {
               "id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               },
               "unit_number": {
                 "$ref": "#/definitions/numberOrString"
               },
               "controller_id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               }
             },
             "required": [
@@ -221,7 +221,7 @@
                 "$ref": "#/definitions/numberOrString"
               },
               "id": {
-                "$ref": "#/definitions/numberOrString"
+                "type": "string"
               }
             },
             "required": [

--- a/coriolis/schemas/volumes_info_schema.json
+++ b/coriolis/schemas/volumes_info_schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://cloudbase.it/coriolis/schemas/volumes_info#",
+  "type": "array",
+  "description": "List of info on volumes replicated to a destination platform. Most fields inside the individual volumes info object are arbitrary and provider-specific, with the exception of 'disk_id'.",
+  "items": {
+    "type": "object",
+    "properties": {
+      "disk_id": {
+        "type": "string",
+        "description": "Unique identifier the *source* disk corresponding to this set of volume info had (should be export_info[devices][disks][id])"
+      }
+    },
+    "required": ["disk_id"],
+    "additionalProperties": true
+  }
+}


### PR DESCRIPTION
Coriolis-core will not both validate the schema of the returned 'volumes_info' of each Replica task, as well as reorder the returned volumes into to match the exact ordering found in `export_info[devices][disks]`.
Also added dedicated schemas for the disk sync resources.
Added the following schemas:
- disk_sync_resources_conn_info_schema.json -- for defining SSH connection params for temporary minion VMs
- disk_sync_resources_info_schema.json -- schema defining volumes_info for disk syncing (both for Migrations and Replicas)

Tested import providers which showed signs of potential disk ordering issues:
- [x] Azure
- [x] OCI -- (up to finalize task)
- [ ] OPC