### PR TITLE
Cleanup replicator integration

### DIFF
--- a/coriolis/providers/replicator.py
+++ b/coriolis/providers/replicator.py
@@ -1,22 +1,21 @@
-import tempfile
-import shutil
-import zipfile
-import json
-import paramiko
 import errno
+import json
 import os
-import time
+import paramiko
 import requests
+import shutil
+import tempfile
+import time
 import uuid
 
-from coriolis import utils
-from coriolis import exception
 from oslo_config import cfg
-
 from oslo_log import log as logging
 from oslo_utils import units
-
 from sshtunnel import SSHTunnelForwarder
+
+from coriolis import exception
+from coriolis import utils
+
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
This makes use of utils.create_service() and refactors a bit the way certificates are copied over from the replicator.

Depends on #46