### PR TITLE
Fix Keystone v3 session

### DIFF
--- a/coriolis/keystone.py
+++ b/coriolis/keystone.py
@@ -15,7 +15,8 @@ opts = [
                default=None,
                help='Default auth URL to be used when not specified in the'
                ' migration\'s connection info.'),
-    cfg.StrOpt('identity_api_version',
+    cfg.IntOpt('identity_api_version',
+               min=2, max=3,
                default=2,
                help='Default Keystone API version.'),
     cfg.BoolOpt('allow_untrusted',

--- a/coriolis/keystone.py
+++ b/coriolis/keystone.py
@@ -164,20 +164,24 @@ def create_keystone_session(ctxt, connection_info={}):
                     "Either 'project_domain_name' or 'project_domain_id' is "
                     "required for Keystone v3 Auth.")
 
-            user_domain_name = connection_info.get(
-                "user_domain_name", ctxt.user_domain_name)
-            if user_domain_name:
-                plugin_args["user_domain_name"] = user_domain_name
+            # NOTE: The v3token plugin does not allow the user_domain_name
+            #       or user_domain_id options, while the v3password plugin
+            #       requires at least any of these.
+            if plugin_name != "v3token":
+                user_domain_name = connection_info.get(
+                    "user_domain_name", ctxt.user_domain_name)
+                if user_domain_name:
+                    plugin_args["user_domain_name"] = user_domain_name
 
-            user_domain_id = connection_info.get(
-                "user_domain_id", ctxt.user_domain_id)
-            if user_domain_id:
-                plugin_args["user_domain_id"] = user_domain_id
+                user_domain_id = connection_info.get(
+                    "user_domain_id", ctxt.user_domain_id)
+                if user_domain_id:
+                    plugin_args["user_domain_id"] = user_domain_id
 
-            if not user_domain_name and not user_domain_id:
-                raise exception.CoriolisException(
-                    "Either 'user_domain_name' or 'user_domain_id' is "
-                    "required for Keystone v3 Auth.")
+                if not user_domain_name and not user_domain_id:
+                    raise exception.CoriolisException(
+                        "Either 'user_domain_name' or 'user_domain_id' is "
+                        "required for Keystone v3 Auth.")
 
         loader = loading.get_plugin_loader(plugin_name)
         auth = loader.load_from_options(**plugin_args)


### PR DESCRIPTION
* Use `IntOpt` for the `identity_api_version` config option
* Fix create_keystone_session method. When using the `v3token` plugin, the `user_domain_name` or
`user_domain_id` must not be set, otherwise the following error is thrown when creating the Keystone v3 session:

    ```
    Exception during message handling:
    TypeError: __init__() got an unexpected keyword argument 'user_domain_name'
    ```

    However, `user_domain_name` or `user_domain_id` are required when using other auth plugins (for example, the `v3password` plugin).