### PR TITLE
Add _set_selinux_autorelabel()

### DIFF
--- a/coriolis/osmorphing/base.py
+++ b/coriolis/osmorphing/base.py
@@ -211,3 +211,11 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
                 "mv -f /%s /%s.bak" % (fstab_chroot_path, fstab_chroot_path))
             self._write_file(
                 fstab_chroot_path, "\n".join(fstab_contents_lines))
+
+    def _set_selinux_autorelabel(self):
+        LOG.debug("setting autorelabel on /")
+        try:
+            self._exec_cmd_chroot(
+                "touch /.autorelabel")
+        except Exception as err:
+            LOG.warning("Failed to set autorelabel: %r" % err)

--- a/coriolis/osmorphing/redhat.py
+++ b/coriolis/osmorphing/redhat.py
@@ -216,5 +216,3 @@ class BaseRedHatMorphingTools(base.BaseLinuxOSMorphingTools):
         return [os.path.join(self._NETWORK_SCRIPTS_PATH, f) for f in
                 dir_content if re.match("^ifcfg-(.*)", f)]
 
-    def _set_selinux_autorelabel(self):
-        self._exec_cmd_chroot("touch /.autorelabel")


### PR DESCRIPTION
Adds _set_selinux_autorelabel() to Linux OS morphers, that when called, will instruct the target system to relabel files on the root partition.