### PR TITLE
Move 'public_ip_address' out of the 'devices' list in the VM info schema.

### DIFF
--- a/coriolis/schemas/vm_export_info_schema.json
+++ b/coriolis/schemas/vm_export_info_schema.json
@@ -65,6 +65,10 @@
       "type": "string",
       "description": "Name of the exported VM's flavor."
     },
+    "public_ip_address": {
+      "type": "string",
+      "description": "Public IP address of the VM. If there are multiple public IP associations, only the main/preferred one should be returned. Should not be set if no such public IP association exists."
+    },
     "devices": {
       "type": "object",
       "description": "Contains information about all of the VM's devices.",
@@ -171,10 +175,6 @@
               "mac_address"
             ]
           }
-        },
-        "public_ip_address": {
-          "type": "string",
-          "description": "Public IP address of the VM. If there are multiple public IP associations, only the main/preferred one should be returned. Should not be set if no such public IP association exists."
         },
         "serial_ports": {
           "type": "array",


### PR DESCRIPTION
While this mixup doesn't directly functionality (the plugins still put the field in the right place), it warrants fixing for the API to be in line with the schema.