### PR TITLE
Copy resolv.conf contents for links during OSMorphing.

### DIFF
--- a/coriolis/osmorphing/base.py
+++ b/coriolis/osmorphing/base.py
@@ -177,7 +177,7 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
         if self._test_path(resolv_conf_path):
             self._exec_cmd(
                 "sudo mv -f %s %s" % (resolv_conf_path, resolv_conf_path_old))
-        self._exec_cmd('sudo cp --remove-destination /etc/resolv.conf %s' %
+        self._exec_cmd('sudo cp -L --remove-destination /etc/resolv.conf %s' %
                        resolv_conf_path)
 
     def _restore_resolv_conf(self):


### PR DESCRIPTION
Depending on the OSMorphing worker VM OS, resolv.conf might be a symlink
with a relative path.
This commit makes Coriolis always copy the contents of resolv.conf when
patching it during the OSMorphing process.