### PR TITLE
Ignore LVM notations, always get device paths.

### DIFF
--- a/coriolis/osmorphing/osmount/base.py
+++ b/coriolis/osmorphing/osmount/base.py
@@ -104,9 +104,9 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
                 continue
             line = line.strip().split(":")
             if pvs.get(line[1]) is None:
-                pvs[line[1]] = [line[0], ]
+                pvs[line[1]] = [self._get_symlink_target(line[0]), ]
             else:
-                pvs[line[1]].append(line[0])
+                pvs[line[1]].append(self._get_symlink_target(line[0]))
         return pvs
 
     def _get_vgnames(self):
@@ -253,6 +253,7 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
         target = None
         try:
             target = self._exec_cmd('readlink -en %s' % symlink).decode()
+            LOG.debug("readlink %s returned: %s" % (symlink, target))
         except Exception:
             LOG.warn('Target not found for symlink: %s' % symlink)
 
@@ -278,7 +279,7 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
         for line in mounts:
             colls = line.split()
             if colls[0].startswith("/dev"):
-                ret.append(colls[0])
+                ret.append(self._get_symlink_target(colls[0]))
         LOG.debug("Currently mounted devices: %s", ret)
         return ret
 
@@ -428,7 +429,7 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
             self._exec_cmd("sudo vgchange -ay %s" % vg_name)
             lvm_dev_paths = self._exec_cmd(
                 "sudo ls /dev/%s/*" % vg_name).decode().split('\n')[:-1]
-            dev_paths += lvm_dev_paths
+            dev_paths += self._get_device_file_paths(lvm_dev_paths)
 
         valid_filesystems = ['ext2', 'ext3', 'ext4', 'xfs', 'btrfs']
 


### PR DESCRIPTION
Fixes: https://cloudbasedev.atlassian.net/projects/COR/issues/COR-144