### PR TITLE
Fix storage rescan

### DIFF
--- a/coriolis/osmorphing/osmount/windows.py
+++ b/coriolis/osmorphing/osmount/windows.py
@@ -54,8 +54,7 @@ class WindowsMountTools(base.BaseOSMountTools):
             pass
 
     def _refresh_storage(self):
-        self._conn.exec_ps_command(
-            "Update-HostStorageCache", ignore_stdout=True)
+        self._run_diskpart_script("RESCAN")
 
     def _run_diskpart_script(self, script):
         """Executes the given script with diskpart.exe.


### PR DESCRIPTION
On older Windows systems there is no Update-HostStorageCache
commandlet. This replaces the powershell rescan with a diskpart
equivalent.