### PR TITLE
Use queueing for SSH backup writer

### DIFF
--- a/coriolis/data_transfer.py
+++ b/coriolis/data_transfer.py
@@ -30,6 +30,7 @@ CONF = cfg.CONF
 CONF.register_opts(compressor_opts)
 
 LOG = logging.getLogger(__name__)
+
 _COMPRESS_FUNC = {
     constants.COMPRESSION_FORMAT_GZIP: gzip.compress,
     constants.COMPRESSION_FORMAT_ZLIB: zlib.compress,


### PR DESCRIPTION
This should speed up the transfer speed when using the SSH backup
writer. Currently, there are 3 operations that happen:

1) Read from the source
2) Compress and encode payload
3) Send payload to destination

These 3 operations run in sequence for each chunk, which means that
while we are reading from the source, we are not compressing or
sending. While we are compressing and encoding, we are not reading
from the source or sending to destination, etc. Using queues allows
us to do more work in parallel.