### PR TITLE
Show deleted migrations/replicas

### DIFF
--- a/coriolis/api/v1/migrations.py
+++ b/coriolis/api/v1/migrations.py
@@ -31,21 +31,8 @@ class MigrationController(api_wsgi.Controller):
 
         return migration_view.single(req, migration)
 
-    def _get_show_deleted(self, val):
-        if val is None:
-            return val
-        try:
-            show_deleted = json.loads(val)
-            if type(show_deleted) is bool:
-                return show_deleted
-        except Exception as err:
-            LOG.warn(
-                "failed to parse show_deleted: %s" % err)
-            pass
-        return None
-
     def index(self, req):
-        show_deleted = self._get_show_deleted(
+        show_deleted = api_utils._get_show_deleted(
             req.GET.get("show_deleted", None))
         context = req.environ["coriolis.context"]
         context.show_deleted = show_deleted
@@ -55,7 +42,7 @@ class MigrationController(api_wsgi.Controller):
                 context, include_tasks=False))
 
     def detail(self, req):
-        show_deleted = self._get_show_deleted(
+        show_deleted = api_utils._get_show_deleted(
             req.GET.get("show_deleted", None))
         context = req.environ["coriolis.context"]
         context.show_deleted = show_deleted

--- a/coriolis/api/v1/replicas.py
+++ b/coriolis/api/v1/replicas.py
@@ -31,17 +31,21 @@ class ReplicaController(api_wsgi.Controller):
 
         return replica_view.single(req, replica)
 
-    def index(self, req, show_deleted=False):
+    def index(self, req):
+        show_deleted = api_utils._get_show_deleted(
+            req.GET.get("show_deleted", None))
         context = req.environ["coriolis.context"]
-        context["show_deleted"] = show_deleted
+        context.show_deleted = show_deleted
         context.can(replica_policies.get_replicas_policy_label("list"))
         return replica_view.collection(
             req, self._replica_api.get_replicas(
                 context, include_tasks_executions=False))
 
-    def detail(self, req, show_deleted=False):
+    def detail(self, req):
+        show_deleted = api_utils._get_show_deleted(
+            req.GET.get("show_deleted", None))
         context = req.environ["coriolis.context"]
-        context["show_deleted"] = show_deleted
+        context.show_deleted = show_deleted
         context.can(
             replica_policies.get_replicas_policy_label("show_executions"))
         return replica_view.collection(

--- a/coriolis/api/v1/replicas.py
+++ b/coriolis/api/v1/replicas.py
@@ -31,15 +31,17 @@ class ReplicaController(api_wsgi.Controller):
 
         return replica_view.single(req, replica)
 
-    def index(self, req):
+    def index(self, req, show_deleted=False):
         context = req.environ["coriolis.context"]
+        context["show_deleted"] = show_deleted
         context.can(replica_policies.get_replicas_policy_label("list"))
         return replica_view.collection(
             req, self._replica_api.get_replicas(
                 context, include_tasks_executions=False))
 
-    def detail(self, req):
+    def detail(self, req, show_deleted=False):
         context = req.environ["coriolis.context"]
+        context["show_deleted"] = show_deleted
         context.can(
             replica_policies.get_replicas_policy_label("show_executions"))
         return replica_view.collection(

--- a/coriolis/api/v1/utils.py
+++ b/coriolis/api/v1/utils.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+import json
 
 from oslo_log import log as logging
 from webob import exc
@@ -10,6 +11,20 @@ from coriolis import schemas
 
 
 LOG = logging.getLogger(__name__)
+
+
+def _get_show_deleted(val):
+    if val is None:
+        return val
+    try:
+        show_deleted = json.loads(val)
+        if type(show_deleted) is bool:
+            return show_deleted
+    except Exception as err:
+        LOG.warn(
+            "failed to parse show_deleted: %s" % err)
+        pass
+    return None
 
 
 def validate_network_map(network_map):

--- a/coriolis/api/v1/views/migration_view.py
+++ b/coriolis/api/v1/views/migration_view.py
@@ -27,10 +27,10 @@ def _format_migration(req, migration, keys=None):
     migration_dict = dict(itertools.chain.from_iterable(
         transform(k, v) for k, v in migration.items()))
 
-    if len(migration_dict["executions"]):
-
+    if len(migration_dict.get("executions", [])):
         execution = view.format_replica_tasks_execution(
             req, migration_dict["executions"][0])
+        del migration_dict["executions"]
     else:
         execution = {}
 
@@ -42,8 +42,6 @@ def _format_migration(req, migration, keys=None):
     if not CONF.include_task_info_in_migrations_api and (
             "info" in migration_dict):
         migration_dict.pop("info")
-
-    del migration_dict["executions"]
     return migration_dict
 
 

--- a/coriolis/api/v1/views/migration_view.py
+++ b/coriolis/api/v1/views/migration_view.py
@@ -5,7 +5,7 @@ import itertools
 
 from oslo_config import cfg as conf
 
-from coriolis.api.v1.views import replica_tasks_execution_view
+from coriolis.api.v1.views import replica_tasks_execution_view as view
 
 
 MIGRATIONS_API_OPTS = [
@@ -27,10 +27,14 @@ def _format_migration(req, migration, keys=None):
     migration_dict = dict(itertools.chain.from_iterable(
         transform(k, v) for k, v in migration.items()))
 
-    execution = replica_tasks_execution_view.format_replica_tasks_execution(
-        req, migration_dict["executions"][0])
+    if len(migration_dict["executions"]):
 
-    migration_dict["status"] = execution["status"]
+        execution = view.format_replica_tasks_execution(
+            req, migration_dict["executions"][0])
+    else:
+        execution = {}
+
+    migration_dict["status"] = execution.get("status")
     tasks = execution.get("tasks")
     if tasks:
         migration_dict["tasks"] = tasks

--- a/coriolis/conductor/rpc/client.py
+++ b/coriolis/conductor/rpc/client.py
@@ -183,9 +183,11 @@ class ConductorClient(object):
         return self._client.call(
             ctxt, 'delete_replica_disks', replica_id=replica_id)
 
-    def get_migrations(self, ctxt, include_tasks=False):
+    def get_migrations(self, ctxt, include_tasks=False,
+                       include_info=False):
         return self._client.call(ctxt, 'get_migrations',
-                                 include_tasks=include_tasks)
+                                 include_tasks=include_tasks,
+                                 include_info=include_info)
 
     def get_migration(self, ctxt, migration_id):
         return self._client.call(

--- a/coriolis/conductor/rpc/server.py
+++ b/coriolis/conductor/rpc/server.py
@@ -536,8 +536,11 @@ class ConductorServerEndpoint(object):
             raise exception.NotFound("Replica not found")
         return replica
 
-    def get_migrations(self, ctxt, include_tasks):
-        return db_api.get_migrations(ctxt, include_tasks)
+    def get_migrations(self, ctxt, include_tasks,
+                       include_info=False):
+        return db_api.get_migrations(
+            ctxt, include_tasks,
+            include_info=include_info)
 
     @migration_synchronized
     def get_migration(self, ctxt, migration_id):

--- a/coriolis/db/api.py
+++ b/coriolis/db/api.py
@@ -276,15 +276,20 @@ def _get_replica_with_tasks_executions_options(q):
 
 
 @enginefacade.reader
-def get_replicas(context, include_tasks_executions=False):
+def get_replicas(context,
+                 include_tasks_executions=False,
+                 include_info=False):
     q = _soft_delete_aware_query(context, models.Replica)
     if include_tasks_executions:
         q = _get_replica_with_tasks_executions_options(q)
+    if include_info is False:
+        q = q.options(orm.defer('info'))
     q = q.filter()
     if is_user_context(context):
         q = q.filter(
             models.Replica.project_id == context.tenant)
-    return q.all()
+    db_result = q.all()
+    return [i.to_dict(include_info=include_info) for i in db_result]
 
 
 @enginefacade.reader

--- a/coriolis/db/api.py
+++ b/coriolis/db/api.py
@@ -248,7 +248,7 @@ def delete_replica_schedule(context, replica_id,
     if is_user_context(context):
         if not q.join(models.Replica).filter(
                 models.Replica.project_id == context.tenant).first():
-                raise exception.NotAuthorized()
+            raise exception.NotAuthorized()
     if pre_delete_callable:
         pre_delete_callable(context, schedule)
     count = q.soft_delete()


### PR DESCRIPTION
In an effort to make available the soft-deleted migrations and replicas to the API consumer, this branch also includes various fixes that needed to be implemented before we could achieve the desired result. As such, as part of this PR, there is also a slightly reworked way of returning results from the conductor to the API server, in a way that avoids serializing a potentially huge object, that includes task_info.