### PR TITLE
Add --worker-process-count argument to relevant components.

### DIFF
--- a/coriolis/cmd/api.py
+++ b/coriolis/cmd/api.py
@@ -12,11 +12,12 @@ CONF = cfg.CONF
 
 
 def main():
-    CONF(sys.argv[1:], project='coriolis',
-         version="1.0.0")
+    worker_count, args = service.get_worker_count_from_args(sys.argv)
+    CONF(args[1:], project='coriolis', version="1.0.0")
     utils.setup_logging()
 
-    server = service.WSGIService('coriolis-api')
+    server = service.WSGIService(
+        'coriolis-api', worker_count=worker_count)
     launcher = service.service.launch(
         CONF, server, workers=server.get_workers_count())
     launcher.wait()

--- a/coriolis/cmd/conductor.py
+++ b/coriolis/cmd/conductor.py
@@ -14,15 +14,15 @@ CONF = cfg.CONF
 
 
 def main():
-    CONF(sys.argv[1:], project='coriolis',
-         version="1.0.0")
+    worker_count, args = service.get_worker_count_from_args(sys.argv)
+    CONF(args[1:], project='coriolis', version="1.0.0")
     utils.setup_logging()
     service.check_locks_dir_empty()
 
     server = service.MessagingService(
         constants.CONDUCTOR_MAIN_MESSAGING_TOPIC,
         [rpc_server.ConductorServerEndpoint()],
-        rpc_server.VERSION)
+        rpc_server.VERSION, worker_count=worker_count)
     launcher = service.service.launch(
         CONF, server, workers=server.get_workers_count())
     launcher.wait()

--- a/coriolis/cmd/worker.py
+++ b/coriolis/cmd/worker.py
@@ -14,14 +14,14 @@ CONF = cfg.CONF
 
 
 def main():
-    CONF(sys.argv[1:], project='coriolis',
-         version="1.0.0")
+    worker_count, args = service.get_worker_count_from_args(sys.argv)
+    CONF(args[1:], project='coriolis', version="1.0.0")
     utils.setup_logging()
 
     server = service.MessagingService(
         constants.WORKER_MAIN_MESSAGING_TOPIC,
         [rpc_server.WorkerServerEndpoint()],
-        rpc_server.VERSION)
+        rpc_server.VERSION, worker_count=worker_count)
     launcher = service.service.launch(
         CONF, server, workers=server.get_workers_count())
     launcher.wait()

--- a/coriolis/worker/rpc/server.py
+++ b/coriolis/worker/rpc/server.py
@@ -23,6 +23,7 @@ from coriolis import events
 from coriolis import exception
 from coriolis.providers import factory as providers_factory
 from coriolis import schemas
+from coriolis import service
 from coriolis.tasks import factory as task_runners_factory
 from coriolis import utils
 
@@ -624,7 +625,8 @@ class WorkerServerEndpoint(object):
 
 def _setup_task_process(mp_log_q):
     # Setting up logging and cfg, needed since this is a new process
-    cfg.CONF(sys.argv[1:], project='coriolis', version="1.0.0")
+    _, args = service.get_worker_count_from_args(sys.argv)
+    cfg.CONF(args[1:], project='coriolis', version="1.0.0")
     utils.setup_logging()
 
     # Log events need to be handled in the parent process


### PR DESCRIPTION
This patch adds a new command line argument ('--worker-process-count')
to the components which need it (API, Conductor, and Worker) to allow
for CLI-based control on the number of worker processes spawned.

Note that this will NOT stop the components from forking if they are
programmed to do so, but merely stops oslo_service from forking the main
process at initial startup.