### PR TITLE
Prevent minion reuse error for Replica deployments.

### DIFF
--- a/coriolis/minion_manager/rpc/server.py
+++ b/coriolis/minion_manager/rpc/server.py
@@ -901,7 +901,8 @@ class MinionManagerServerEndpoint(object):
                 if action['destination_minion_pool_id'] and (
                         include_osmorphing_minions and (
                             osmorphing_pool_id == (
-                                action['destination_minion_pool_id']))):
+                                action['destination_minion_pool_id']) and (
+                                    include_transfer_minions))):
                     LOG.debug(
                         "Reusing destination minion pool with ID '%s' for the "
                         "following instances which had it selected as an "


### PR DESCRIPTION
Ensure that the minion manager does not bother trying to reuse
destination transfer minions for Replica deployments or if no transfer
minions were requested to begin with.