### PR TITLE
Update DB layer for SQLAlchemy 1.4.

### DIFF
--- a/coriolis/db/api.py
+++ b/coriolis/db/api.py
@@ -306,8 +306,11 @@ def add_replica_tasks_execution(context, execution):
 
     # include deleted records
     max_number = _model_query(
-        context, func.max(models.TasksExecution.number)).filter_by(
-            action_id=execution.action.id).first()[0] or 0
+        context,
+        func.max(
+            models.TasksExecution.number)).filter(
+                models.TasksExecution.action_id==(
+                    execution.action.id)).first()[0] or 0
     execution.number = max_number + 1
 
     _session(context).add(execution)
@@ -1387,21 +1390,6 @@ def get_minion_pools(
                 include_progress_updates=include_progress_updates)
             for i in db_result]
     return db_result
-
-
-@enginefacade.writer
-def add_minion_pool_execution(context, execution):
-    if is_user_context(context):
-        if execution.action.project_id != context.tenant:
-            raise exception.NotAuthorized()
-
-    # include deleted records
-    max_number = _model_query(
-        context, func.max(models.TasksExecution.number)).filter_by(
-            action_id=execution.action.id).first()[0] or 0
-    execution.number = max_number + 1
-
-    _session(context).add(execution)
 
 
 @enginefacade.writer

--- a/coriolis/db/sqlalchemy/migrate_repo/versions/009_Migrate_info_to_blob.py
+++ b/coriolis/db/sqlalchemy/migrate_repo/versions/009_Migrate_info_to_blob.py
@@ -9,5 +9,4 @@ def upgrade(migrate_engine):
     base_transfer_action = sqlalchemy.Table(
         'base_transfer_action', meta, autoload=True)
 
-    base_transfer_action.c.info.alter(type=types.Binary(4294967295))
-
+    base_transfer_action.c.info.alter(type=types.LargeBinary(4294967295))

--- a/coriolis/db/sqlalchemy/types.py
+++ b/coriolis/db/sqlalchemy/types.py
@@ -32,7 +32,7 @@ class LongText(types.TypeDecorator):
 
 
 class Blob(types.TypeDecorator):
-    impl = types.Binary
+    impl = types.LargeBinary
 
     def load_dialect_impl(self, dialect):
         if dialect.name == 'mysql':


### PR DESCRIPTION
Changes are:
    - switching base_transfer_action.info base sqlalchemy type from
      to `LongBinary` since plain `Binary` no longer exists.
      This should not affect existing deployments since the underlying
      SQL type is still `longblob`
    - use `filter` instead of `filter_by` for `max` queries.