### PR TITLE
[WiP] Prevent API service from resetting RPC connections.

### DIFF
--- a/coriolis/conductor/rpc/client.py
+++ b/coriolis/conductor/rpc/client.py
@@ -25,12 +25,14 @@ CONF.register_opts(conductor_opts, 'conductor')
 
 class ConductorClient(rpc.BaseRPCClient):
     def __init__(self, timeout=None,
-                 topic=constants.CONDUCTOR_MAIN_MESSAGING_TOPIC):
+                 topic=constants.CONDUCTOR_MAIN_MESSAGING_TOPIC,
+                 reset_transport_on_call=True):
         target = messaging.Target(topic=topic, version=VERSION)
         if timeout is None:
             timeout = CONF.conductor.conductor_rpc_timeout
         super(ConductorClient, self).__init__(
-            target, timeout=timeout)
+            target, timeout=timeout,
+            reset_transport_on_call=reset_transport_on_call)
 
     def create_endpoint(self, ctxt, name, endpoint_type, description,
                         connection_info, mapped_regions):

--- a/coriolis/diagnostics/api.py
+++ b/coriolis/diagnostics/api.py
@@ -7,9 +7,8 @@ from coriolis.worker.rpc import client as worker_rpc
 
 class API(object):
     def __init__(self):
-        self._conductor_cli = conductor_rpc.ConductorClient()
-        self._cron_cli = cron_rpc.ReplicaCronClient()
-        self._worker_cli = worker_rpc.WorkerClient()
+        self._conductor_cli = conductor_rpc.ConductorClient(
+            reset_transport_on_call=False)
 
     def get(self, ctxt):
         diag = self._conductor_cli.get_all_diagnostics(ctxt)

--- a/coriolis/endpoint_options/api.py
+++ b/coriolis/endpoint_options/api.py
@@ -8,8 +8,10 @@ from coriolis.minion_manager.rpc import client as rpc_minion_manager_client
 class API(object):
     def __init__(self):
         self._rpc_minion_manager_client = (
-            rpc_minion_manager_client.MinionManagerClient())
-        self._rpc_conductor_client = rpc_conductor_client.ConductorClient()
+            rpc_minion_manager_client.MinionManagerClient(
+                reset_transport_on_call=False))
+        self._rpc_conductor_client = rpc_conductor_client.ConductorClient(
+            reset_transport_on_call=False)
 
     def get_endpoint_source_options(
             self, ctxt, endpoint_id, env=None, option_names=None):

--- a/coriolis/endpoints/api.py
+++ b/coriolis/endpoints/api.py
@@ -8,9 +8,11 @@ from coriolis.minion_manager.rpc import client as rpc_minion_manager_client
 
 class API(object):
     def __init__(self):
-        self._rpc_conductor_client = rpc_conductor_client.ConductorClient()
+        self._rpc_conductor_client = rpc_conductor_client.ConductorClient(
+            reset_transport_on_call=False)
         self._rpc_minion_manager_client = (
-            rpc_minion_manager_client.MinionManagerClient())
+            rpc_minion_manager_client.MinionManagerClient(
+                reset_transport_on_call=False))
 
     def create(self, ctxt, name, endpoint_type, description,
                connection_info, mapped_regions):

--- a/coriolis/migrations/api.py
+++ b/coriolis/migrations/api.py
@@ -6,7 +6,8 @@ from coriolis.conductor.rpc import client as rpc_client
 
 class API(object):
     def __init__(self):
-        self._rpc_client = rpc_client.ConductorClient()
+        self._rpc_client = rpc_client.ConductorClient(
+            reset_transport_on_call=False)
 
     def migrate_instances(self, ctxt, origin_endpoint_id,
                           destination_endpoint_id, origin_minion_pool_id,

--- a/coriolis/minion_manager/rpc/client.py
+++ b/coriolis/minion_manager/rpc/client.py
@@ -25,12 +25,15 @@ CONF.register_opts(MINION_MANAGER_OPTS, 'minion_manager')
 
 class MinionManagerClient(rpc.BaseRPCClient):
 
-    def __init__(self, timeout=None):
-        target = messaging.Target(topic='coriolis_minion_manager', version=VERSION)
+    def __init__(self, timeout=None, reset_transport_on_call=True):
+        target = messaging.Target(
+            topic=constants.MINION_MANAGER_MAIN_MESSAGING_TOPIC,
+            version=VERSION)
         if timeout is None:
             timeout = CONF.minion_manager.minion_mananger_rpc_timeout
         super(MinionManagerClient, self).__init__(
-            target, timeout=timeout)
+            target, timeout=timeout,
+            reset_transport_on_call=reset_transport_on_call)
 
     def add_minion_pool_progress_update(
             self, ctxt, minion_pool_id, message, initial_step=0, total_steps=0,

--- a/coriolis/minion_pools/api.py
+++ b/coriolis/minion_pools/api.py
@@ -7,7 +7,8 @@ from coriolis.minion_manager.rpc import client as rpc_client
 
 class API(object):
     def __init__(self):
-        self._rpc_client = rpc_client.MinionManagerClient()
+        self._rpc_client = rpc_client.MinionManagerClient(
+            reset_transport_on_call=False)
 
     def create(
             self, ctxt, name, endpoint_id, pool_platform, pool_os_type,

--- a/coriolis/regions/api.py
+++ b/coriolis/regions/api.py
@@ -7,7 +7,8 @@ from coriolis.conductor.rpc import client as rpc_client
 
 class API(object):
     def __init__(self):
-        self._rpc_client = rpc_client.ConductorClient()
+        self._rpc_client = rpc_client.ConductorClient(
+            reset_transport_on_call=False)
 
     def create(self, ctxt, region_name, description, enabled=True):
         return self._rpc_client.create_region(

--- a/coriolis/replica_cron/rpc/client.py
+++ b/coriolis/replica_cron/rpc/client.py
@@ -10,10 +10,13 @@ VERSION = "1.0"
 
 
 class ReplicaCronClient(rpc.BaseRPCClient):
-    def __init__(self, topic=constants.REPLICA_CRON_MAIN_MESSAGING_TOPIC):
+    def __init__(
+            self, topic=constants.REPLICA_CRON_MAIN_MESSAGING_TOPIC,
+            reset_transport_on_call=True):
         target = messaging.Target(
             topic=topic, version=VERSION)
-        super(ReplicaCronClient, self).__init__(target)
+        super(ReplicaCronClient, self).__init__(
+            target, reset_transport_on_call=reset_transport_on_call)
 
     def register(self, ctxt, schedule):
         self._call(ctxt, 'register', schedule=schedule)

--- a/coriolis/replica_tasks_executions/api.py
+++ b/coriolis/replica_tasks_executions/api.py
@@ -6,7 +6,8 @@ from coriolis.conductor.rpc import client as rpc_client
 
 class API(object):
     def __init__(self):
-        self._rpc_client = rpc_client.ConductorClient()
+        self._rpc_client = rpc_client.ConductorClient(
+            reset_transport_on_call=False)
 
     def create(self, ctxt, replica_id, shutdown_instances):
         return self._rpc_client.execute_replica_tasks(

--- a/coriolis/replicas/api.py
+++ b/coriolis/replicas/api.py
@@ -6,7 +6,8 @@ from coriolis.conductor.rpc import client as rpc_client
 
 class API(object):
     def __init__(self):
-        self._rpc_client = rpc_client.ConductorClient()
+        self._rpc_client = rpc_client.ConductorClient(
+            reset_transport_on_call=False)
 
     def create(self, ctxt, origin_endpoint_id, destination_endpoint_id,
                origin_minion_pool_id, destination_minion_pool_id,

--- a/coriolis/worker/rpc/client.py
+++ b/coriolis/worker/rpc/client.py
@@ -22,7 +22,8 @@ CONF.register_opts(worker_opts, 'worker')
 class WorkerClient(rpc.BaseRPCClient):
     def __init__(
             self, timeout=None, host=None,
-            base_worker_topic=constants.WORKER_MAIN_MESSAGING_TOPIC):
+            base_worker_topic=constants.WORKER_MAIN_MESSAGING_TOPIC,
+            reset_transport_on_call=True):
         topic = base_worker_topic
         if host is not None:
             topic = constants.SERVICE_MESSAGING_TOPIC_FORMAT % ({
@@ -32,7 +33,8 @@ class WorkerClient(rpc.BaseRPCClient):
         if timeout is None:
             timeout = CONF.worker.worker_rpc_timeout
         super(WorkerClient, self).__init__(
-            target, timeout=timeout)
+            target, timeout=timeout,
+            reset_transport_on_call=reset_transport_on_call)
 
     @classmethod
     def from_service_definition(


### PR DESCRIPTION
This PR prevents the Coriolis API service from resetting RPC transports
every time like the other components since in the RPC service's case
there is no "internal" forking involved and instead the service processes
are created on startup.