### PR TITLE
Add version requirement for oslo_messaging and kombu.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,10 @@ eventlet
 keystoneauth1
 keystonemiddleware
 jsonschema
+# NOTE (aznashwan, 21-03-31): kombu>=5 has some weird interactions with
+# oslo_messaging which causes extreme RAM usage in the API service,
+# so we limit its version here.
+kombu==4.6.10
 PyMySQL
 oslo.cache
 oslo.concurrency
@@ -10,7 +14,7 @@ oslo.context>=2.19.1
 oslo.db
 oslo.i18n
 oslo.log
-oslo.messaging
+oslo.messaging==12.2.0
 oslo.middleware
 oslo.policy
 oslo.serialization


### PR DESCRIPTION
The latest versions oslo_messaging and kombu cause exterme RAM usage in
the API service. Coriolis can be ruled out as the cause as individual
testing showed kombu to the single biggest factor.
This PR mitigates this by pinning both to their prior major releases.