### PR TITLE
Futureproof setup.cfg by replacing dashes with underscores.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = coriolis
 summary = Migration as a Service
-description-file =
+description_file =
     README.rst
 author = Cloudbase Solutions SRL
-author-email = info@cloudbasesolutions.com
-home-page = http://cloudbase.it
+author_email = info@cloudbasesolutions.com
+home_page = http://cloudbase.it
 classifier =
     Environment :: OpenStack
     Intended Audience :: Information Technology


### PR DESCRIPTION
`setuptools` will deprecate usage of dashes in the metadata fields from
setup.cfg.