### PR TITLE
Fix Ubuntu OSMorphing cloud config YAML loading for PyYAML 6+.

### DIFF
--- a/coriolis/osmorphing/ubuntu.py
+++ b/coriolis/osmorphing/ubuntu.py
@@ -60,7 +60,8 @@ class BaseUbuntuMorphingTools(debian.BaseDebianMorphingTools):
 
             config_contents = self._read_file(config_path_chroot)
             config_data = yaml.load(
-                io.StringIO(config_contents.decode("utf-8")))
+                io.StringIO(config_contents.decode("utf-8")),
+                Loader=yaml.SafeLoader)
 
             config_network_data = config_data.get("network")
             if config_network_data is None:


### PR DESCRIPTION
Starting with PyYAML 6.0, calling `yaml.loads("thing")` without explicitly passing in a `Loader=` kwarg has been deprecated.

To maintain the same functionality, we simply pass in `Loader=yaml.SafeLoader` to the YAML loading call. 