### PR TITLE
Check replica volumes exist before raising storage mapping update error

### DIFF
--- a/coriolis/providers/provider_utils.py
+++ b/coriolis/providers/provider_utils.py
@@ -111,6 +111,9 @@ def get_storage_mapping_for_disk(
 
 def check_changed_storage_mappings(volumes_info, old_storage_mappings,
                                    new_storage_mappings):
+        if not volumes_info:
+            return
+
         old_backend_mappings = old_storage_mappings.get('backend_mappings', [])
         old_disk_mappings = old_storage_mappings.get('disk_mappings', [])
         new_backend_mappings = new_storage_mappings.get('backend_mappings', [])


### PR DESCRIPTION
Any storage mapping update automatically fails, without checking whether the `volumes_info` actually exists or not. `volumes_info` argument wasn't used up to this point, this may be the main reason we kept passing it.