### PR TITLE
Add `include_task_info` to action DB fetching operations

### DIFF
--- a/coriolis/api/v1/views/migration_view.py
+++ b/coriolis/api/v1/views/migration_view.py
@@ -3,19 +3,7 @@
 
 import itertools
 
-from oslo_config import cfg as conf
-
 from coriolis.api.v1.views import replica_tasks_execution_view as view
-
-
-MIGRATIONS_API_OPTS = [
-    conf.BoolOpt("include_task_info_in_migrations_api",
-                 default=False,
-                 help="Whether or not to expose the internal 'info' field of "
-                      "a Migration as part of a `GET` request.")]
-
-CONF = conf.CONF
-CONF.register_opts(MIGRATIONS_API_OPTS)
 
 
 def _format_migration(req, migration, keys=None):
@@ -39,9 +27,6 @@ def _format_migration(req, migration, keys=None):
     if tasks:
         migration_dict["tasks"] = tasks
 
-    if not CONF.include_task_info_in_migrations_api and (
-            "info" in migration_dict):
-        migration_dict.pop("info")
     return migration_dict
 
 

--- a/coriolis/api/v1/views/replica_tasks_execution_view.py
+++ b/coriolis/api/v1/views/replica_tasks_execution_view.py
@@ -3,24 +3,12 @@
 
 import itertools
 
-from oslo_config import cfg as conf
 from oslo_log import log as logging
 
 from coriolis import constants
-from coriolis import utils
 
 
 LOG = logging.getLogger(__name__)
-
-
-REPLICA_EXECUTION_API_OPTS = [
-    conf.BoolOpt("include_task_info_in_replica_executions_api",
-                 default=False,
-                 help="Whether or not to expose the internal 'info' field of "
-                      "a Replica execution as part of a `GET` request.")]
-
-CONF = conf.CONF
-CONF.register_opts(REPLICA_EXECUTION_API_OPTS)
 
 
 def _sort_tasks(tasks, filter_error_only_tasks=True):
@@ -47,12 +35,6 @@ def format_replica_tasks_execution(req, execution, keys=None):
 
     execution_dict = dict(itertools.chain.from_iterable(
         transform(k, v) for k, v in execution.items()))
-
-    if not CONF.include_task_info_in_replica_executions_api and (
-            "action" in execution_dict):
-        action_dict = execution_dict["action"]
-        if "info" in action_dict:
-            action_dict.pop("info")
 
     return execution_dict
 

--- a/coriolis/api/v1/views/replica_view.py
+++ b/coriolis/api/v1/views/replica_view.py
@@ -3,19 +3,7 @@
 
 import itertools
 
-from oslo_config import cfg as conf
-
 from coriolis.api.v1.views import replica_tasks_execution_view as view
-
-
-REPLICA_API_OPTS = [
-    conf.BoolOpt("include_task_info_in_replicas_api",
-                 default=False,
-                 help="Whether or not to expose the internal 'info' field of "
-                      "a Replica as part of a `GET` request.")]
-
-CONF = conf.CONF
-CONF.register_opts(REPLICA_API_OPTS)
 
 
 def _format_replica(req, replica, keys=None):
@@ -31,10 +19,6 @@ def _format_replica(req, replica, keys=None):
     replica_dict['executions'] = [
         view.format_replica_tasks_execution(req, ex)
         for ex in executions]
-
-    if not CONF.include_task_info_in_replicas_api and (
-            "info" in replica_dict):
-        replica_dict.pop("info")
 
     return replica_dict
 

--- a/coriolis/conductor/rpc/client.py
+++ b/coriolis/conductor/rpc/client.py
@@ -142,10 +142,11 @@ class ConductorClient(rpc.BaseRPCClient):
             replica_id=replica_id,
             include_tasks=include_tasks)
 
-    def get_replica_tasks_execution(self, ctxt, replica_id, execution_id):
+    def get_replica_tasks_execution(self, ctxt, replica_id, execution_id,
+                                    include_task_info=False):
         return self._call(
             ctxt, 'get_replica_tasks_execution', replica_id=replica_id,
-            execution_id=execution_id)
+            execution_id=execution_id, include_task_info=include_task_info)
 
     def delete_replica_tasks_execution(self, ctxt, replica_id, execution_id):
         return self._call(
@@ -182,14 +183,17 @@ class ConductorClient(rpc.BaseRPCClient):
             source_environment=source_environment,
             user_scripts=user_scripts)
 
-    def get_replicas(self, ctxt, include_tasks_executions=False):
+    def get_replicas(self, ctxt, include_tasks_executions=False,
+                     include_task_info=False):
         return self._call(
             ctxt, 'get_replicas',
-            include_tasks_executions=include_tasks_executions)
+            include_tasks_executions=include_tasks_executions,
+            include_task_info=include_task_info)
 
-    def get_replica(self, ctxt, replica_id):
+    def get_replica(self, ctxt, replica_id, include_task_info=False):
         return self._call(
-            ctxt, 'get_replica', replica_id=replica_id)
+            ctxt, 'get_replica', replica_id=replica_id,
+            include_task_info=include_task_info)
 
     def delete_replica(self, ctxt, replica_id):
         self._call(
@@ -200,14 +204,15 @@ class ConductorClient(rpc.BaseRPCClient):
             ctxt, 'delete_replica_disks', replica_id=replica_id)
 
     def get_migrations(self, ctxt, include_tasks=False,
-                       include_info=False):
+                       include_task_info=False):
         return self._call(
             ctxt, 'get_migrations', include_tasks=include_tasks,
-            include_info=include_info)
+            include_task_info=include_task_info)
 
-    def get_migration(self, ctxt, migration_id):
+    def get_migration(self, ctxt, migration_id, include_task_info=False):
         return self._call(
-            ctxt, 'get_migration', migration_id=migration_id)
+            ctxt, 'get_migration', migration_id=migration_id,
+            include_task_info=include_task_info)
 
     def migrate_instances(self, ctxt, origin_endpoint_id,
                           destination_endpoint_id, origin_minion_pool_id,

--- a/coriolis/migrations/api.py
+++ b/coriolis/migrations/api.py
@@ -44,8 +44,11 @@ class API(object):
     def cancel(self, ctxt, migration_id, force):
         self._rpc_client.cancel_migration(ctxt, migration_id, force)
 
-    def get_migrations(self, ctxt, include_tasks=False):
-        return self._rpc_client.get_migrations(ctxt, include_tasks)
+    def get_migrations(self, ctxt, include_tasks=False,
+                       include_task_info=False):
+        return self._rpc_client.get_migrations(
+            ctxt, include_tasks, include_task_info=include_task_info)
 
-    def get_migration(self, ctxt, migration_id):
-        return self._rpc_client.get_migration(ctxt, migration_id)
+    def get_migration(self, ctxt, migration_id, include_task_info=False):
+        return self._rpc_client.get_migration(
+            ctxt, migration_id, include_task_info=include_task_info)

--- a/coriolis/replicas/api.py
+++ b/coriolis/replicas/api.py
@@ -27,11 +27,15 @@ class API(object):
     def delete(self, ctxt, replica_id):
         self._rpc_client.delete_replica(ctxt, replica_id)
 
-    def get_replicas(self, ctxt, include_tasks_executions=False):
-        return self._rpc_client.get_replicas(ctxt, include_tasks_executions)
+    def get_replicas(self, ctxt, include_tasks_executions=False,
+                     include_task_info=False):
+        return self._rpc_client.get_replicas(
+            ctxt, include_tasks_executions,
+            include_task_info=include_task_info)
 
-    def get_replica(self, ctxt, replica_id):
-        return self._rpc_client.get_replica(ctxt, replica_id)
+    def get_replica(self, ctxt, replica_id, include_task_info=False):
+        return self._rpc_client.get_replica(
+            ctxt, replica_id, include_task_info=include_task_info)
 
     def delete_disks(self, ctxt, replica_id):
         return self._rpc_client.delete_replica_disks(ctxt, replica_id)


### PR DESCRIPTION
 -  Adds `include_task_info` option to all DB API action fetching methods that
    will control the loading of `info` column for a `BaseTransferAction`.
    Also adds `to_dict` option that turns the model objects into dictionaries
    for GET requests. This is necessary because serialization of model objects
    with deferred columns is not possible without an active DB session.

 -  Expose `include_task_info` parameters to `include_tasks_info_in_api` config options