### PR TITLE
Remove migration `status` from API response view

### DIFF
--- a/coriolis/api/v1/views/migration_view.py
+++ b/coriolis/api/v1/views/migration_view.py
@@ -22,7 +22,6 @@ def _format_migration(req, migration, keys=None):
     else:
         execution = {}
 
-    migration_dict["status"] = execution.get("status")
     tasks = execution.get("tasks")
     if tasks:
         migration_dict["tasks"] = tasks


### PR DESCRIPTION
`last_execution_status` key from DB should be used instead.