### PR TITLE
Prevent SSH command output decoding from raising exceptions

### DIFF
--- a/coriolis/utils.py
+++ b/coriolis/utils.py
@@ -318,7 +318,9 @@ def exec_ssh_cmd(ssh, cmd, environment=None, get_pty=False, timeout=None):
         raise exception.CoriolisException(
             "Command \"%s\" failed on host '%s' with exit code: %s\n"
             "stdout: %s\nstd_err: %s" %
-            (cmd, remote_str, exit_code, std_out.decode(), std_err.decode()))
+            (cmd, remote_str, exit_code,
+             std_out.decode(errors='ignore'),
+             std_err.decode(errors='ignore')))
     # Most of the commands will use pseudo-terminal which unfortunately will
     # include a '\r' to every newline. This will affect all plugins too, so
     # best we can do now is replace them.


### PR DESCRIPTION
If a stdout or stderr stirng decoding may fail, it will raise an exception and
may wrongfully interrupt a running task. This patch will ignore string
decoding errors and, if decoding errors do occur, output the encoded
bytestring.