### PR TITLE
Logging message improvements

### DIFF
--- a/coriolis/osmorphing/osmount/windows.py
+++ b/coriolis/osmorphing/osmount/windows.py
@@ -103,10 +103,6 @@ class WindowsMountTools(base.BaseOSMountTools):
                                 "with status '%s'.Skipping running script '%s'"
                                 ". Error message: %s" % (
                                     disk_id, status, script, ex))
-                            self._event_manager.progress_update(
-                                "Exception ocurred while servicing disk '%s' "
-                                "with status '%s'. Skipping servicing disk" % (
-                                    disk_id, status))
                         else:
                             raise
                     break

--- a/coriolis/providers/backup_writers.py
+++ b/coriolis/providers/backup_writers.py
@@ -281,7 +281,7 @@ class SSHBackupWriterImpl(BaseBackupWriterImpl):
             "Guest path: %(path)s, offset: %(offset)d, content len: "
             "%(content_len)d, msg len: %(msg_len)d",
             {"path": self._path,
-             "offset": self._offset,
+             "offset": offset,
              "content_len": len(content),
              "msg_len": len(msg)})
         return msg
@@ -658,10 +658,16 @@ class HTTPBackupWriterImpl(BaseBackupWriterImpl):
             @utils.retry_on_error()
             def send():
                 self._ensure_session()
+                chunk = copy.copy(payload["chunk"])
+                LOG.debug(
+                    "Guest path: %(path)s, offset: %(offset)d, content len: "
+                    "%(content_len)d",
+                    {"path": self._path,
+                     "offset": offset,
+                     "content_len": len(chunk)})
                 resp = self._session.post(
-                    self._uri, headers=headers, data=copy.copy(payload["chunk"]),
-                    timeout=CONF.default_requests_timeout
-                )
+                    self._uri, headers=headers, data=chunk,
+                    timeout=CONF.default_requests_timeout)
                 LOG.debug(
                     "Response code: %r, content: %r" %
                     (resp.status_code, resp.content))


### PR DESCRIPTION
These patches include the following:
1. Fixes backup writer offset logging, by logging the right offset when the transfer finishes, so no duplicate offsets will show up in the logs.
2. Adds verbose logging to HTTP writer
3. Removes `Exception ocurred while servicing disk` progress update. Only the logged warning message remains.