### PR TITLE
Fix requirements for running workflow tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ paramiko>=2.1.0
 paste
 pbr
 psutil
-pyOpenSSL
+pyOpenSSL>=21.0.0
 python-keystoneclient
 # required by `oslo_cache` when imported by `keystonemiddleware`
 python-memcached>=1.56
@@ -38,7 +38,7 @@ requests
 mysqlclient
 schedule
 strict-rfc3339
-sqlalchemy
+sqlalchemy<2.0.0
 taskflow
 webob
 sshtunnel


### PR DESCRIPTION
Fixes requirement pip installation on newer Operating Systems that deprecated OpenSSL 1.1.

Limits `sqlalchemy` version, since `sqlalchemy-migrate` has been also deprecated.