### PR TITLE
Add `secure_boot` field to VM Export Information

### DIFF
--- a/coriolis/schemas/vm_export_info_schema.json
+++ b/coriolis/schemas/vm_export_info_schema.json
@@ -57,6 +57,10 @@
       "description": "The type of firmware of the VM.",
       "enum": ["BIOS", "EFI"]
     },
+    "secure_boot": {
+      "type": "boolean",
+      "description": "Whether the machine has UEFI Secure Boot enabled or not."
+    },
     "nested_virtualization": {
       "type": "boolean",
       "description": "Indicates whether or not nested hardware accelerated virtualization is possible on the VM."


### PR DESCRIPTION
Adds a field that will tell whether the exported machine has UEFI Secure Boot enabled or not.