### PR TITLE
Add `InvalidInstanceState` exception type

### DIFF
--- a/coriolis/exception.py
+++ b/coriolis/exception.py
@@ -237,6 +237,10 @@ class InvalidReplicaState(Invalid):
     message = _("Invalid replica state: %(reason)s")
 
 
+class InvalidInstanceState(Invalid):
+    message = _("Invalid instance state: %(reason)s")
+
+
 class ExecutionDeadlockException(CoriolisException):
     message = _("Execution is bound to be deadlocked.")
 


### PR DESCRIPTION
Should be raised when there’s an invalid VM state.