### PR TITLE
Regenerate all initrds using dracut command

### DIFF
--- a/coriolis/osmorphing/oracle.py
+++ b/coriolis/osmorphing/oracle.py
@@ -20,10 +20,6 @@ class BaseOracleMorphingTools(redhat.BaseRedHatMorphingTools):
         return cls._version_supported_util(
             detected_os_info['release_version'], minimum=6)
 
-    def _run_dracut(self):
-        self._run_dracut_base('kernel')
-        self._run_dracut_base('kernel-uek')
-
     def _get_oracle_repos(self):
         repos = []
         major_version = int(self._version.split(".")[0])

--- a/coriolis/osmorphing/redhat.py
+++ b/coriolis/osmorphing/redhat.py
@@ -276,28 +276,7 @@ class BaseRedHatMorphingTools(base.BaseLinuxOSMorphingTools):
         self._yum_uninstall(package_names)
 
     def _run_dracut(self):
-        self._run_dracut_base('kernel')
-
-    def _run_dracut_base(self, rpm_base_name):
-        package_names = []
-        try:
-            package_names = self._exec_cmd_chroot(
-                'rpm -q %s' % rpm_base_name).decode().splitlines()
-        except Exception as ex:
-            self._event_manager.progress_update(
-                "Failed to query kernel package name: '%s'. Unable to rebuild"
-                " initrd for the new platform" % rpm_base_name)
-            LOG.exception(ex)
-
-        for package_name in package_names:
-            m = re.match('^%s-(.*)$' % rpm_base_name, package_name)
-            if m:
-                kernel_version = m.groups()[0]
-                self._event_manager.progress_update(
-                    "Generating initrd for kernel: %s" % kernel_version)
-                self._exec_cmd_chroot(
-                    "dracut -f /boot/initramfs-%(version)s.img %(version)s" %
-                    {"version": kernel_version})
+        self._exec_cmd_chroot("dracut --regenerate-all -f")
 
     def _set_network_nozeroconf_config(self):
         network_cfg_file = "etc/sysconfig/network"

--- a/coriolis/osmorphing/suse.py
+++ b/coriolis/osmorphing/suse.py
@@ -63,17 +63,7 @@ class BaseSUSEMorphingTools(base.BaseLinuxOSMorphingTools):
         pass
 
     def _run_dracut(self):
-        package_names = self._exec_cmd_chroot(
-            'rpm -q kernel-default').decode().splitlines()
-        for package_name in package_names:
-            m = re.match(r'^kernel-default-(.*)\.\d\..*$', package_name)
-            if m:
-                kernel_version = "%s-default" % m.groups()[0]
-                self._event_manager.progress_update(
-                    "Generating initrd for kernel: %s" % kernel_version)
-                self._exec_cmd_chroot(
-                    "dracut -f /boot/initrd-%(version)s %(version)s" %
-                    {"version": kernel_version})
+        self._exec_cmd_chroot("dracut --regenerate-all -f")
 
     def _run_mkinitrd(self):
         self._event_manager.progress_update("Rebuilding initrds")


### PR DESCRIPTION
When regenerating initrds, Coriolis would only regenerate for official kernel versions and RPM packages. This patch makes use of `dracut --regenerate-all` command to make sure that all initrds are regenerated in the OS Morphing process.