### PR TITLE
Fix deprecation of `sqlalchemy migrate` in `oslo.db`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ oslo.cache
 oslo.concurrency
 oslo.config
 oslo.context>=2.19.1
-oslo.db
+oslo.db<=12.3.2
 oslo.i18n
 oslo.log
 oslo.messaging==12.2.0


### PR DESCRIPTION
`oslo.db` has removed `sqlalchemy.migrate` module after sqlalchemy-migration has been deprecated (https://github.com/cloudbase/coriolis/pull/248). This patch pins down `oslo.db` to the last version this module still exists, until proper fix (switching to `alembic` DB migrations).