### PR TITLE
Upgrade RHEL-based OSMorphing Tools

### DIFF
--- a/coriolis/osmorphing/centos.py
+++ b/coriolis/osmorphing/centos.py
@@ -7,14 +7,16 @@ from coriolis.osmorphing.osdetect import centos as centos_detect
 
 
 CENTOS_DISTRO_IDENTIFIER = centos_detect.CENTOS_DISTRO_IDENTIFIER
+CENTOS_STREAM_DISTRO_IDENTIFIER = centos_detect.CENTOS_STREAM_DISTRO_IDENTIFIER
 
 
 class BaseCentOSMorphingTools(redhat.BaseRedHatMorphingTools):
 
     @classmethod
     def check_os_supported(cls, detected_os_info):
-        if detected_os_info['distribution_name'] != (
-                CENTOS_DISTRO_IDENTIFIER):
+        supported_oses = [
+            CENTOS_STREAM_DISTRO_IDENTIFIER, CENTOS_DISTRO_IDENTIFIER]
+        if detected_os_info['distribution_name'] not in supported_oses:
             return False
         return cls._version_supported_util(
             detected_os_info['release_version'], minimum=6)

--- a/coriolis/osmorphing/oracle.py
+++ b/coriolis/osmorphing/oracle.py
@@ -23,6 +23,7 @@ class BaseOracleMorphingTools(redhat.BaseRedHatMorphingTools):
     def _get_oracle_repos(self):
         repos = []
         major_version = int(self._version.split(".")[0])
+        uekr_version = int(major_version) - 2
         if major_version < 8:
             repo_file_path = (
                 '/etc/yum.repos.d/%s.repo' % str(uuid.uuid4()))
@@ -45,7 +46,8 @@ class BaseOracleMorphingTools(redhat.BaseRedHatMorphingTools):
                 self._find_yum_repos(['ol%s_baseos_latest' % major_version]))
             repos_to_enable = ["ol%s_baseos_latest" % major_version,
                                "ol%s_appstream" % major_version,
-                               "ol%s_UEKR6" % major_version]
+                               "ol%d_addons" % major_version,
+                               "ol%s_UEKR%s" % (major_version, uekr_version)]
             repos = self._find_yum_repos(repos_to_enable)
 
         return repos

--- a/coriolis/osmorphing/osdetect/centos.py
+++ b/coriolis/osmorphing/osdetect/centos.py
@@ -4,13 +4,13 @@
 import re
 
 from oslo_log import log as logging
-
 from coriolis import constants
 from coriolis.osmorphing.osdetect import base
 
 
 LOG = logging.getLogger(__name__)
 CENTOS_DISTRO_IDENTIFIER = "CentOS"
+CENTOS_STREAM_DISTRO_IDENTIFIER = "CentOS Stream"
 
 
 class CentOSOSDetectTools(base.BaseLinuxOSDetectTools):
@@ -22,19 +22,22 @@ class CentOSOSDetectTools(base.BaseLinuxOSDetectTools):
             release_info = self._read_file(
                 redhat_release_path).decode().splitlines()
             if release_info:
-                m = re.match(r"^(.*) release ([0-9].*) \((.*)\).*$",
+                m = re.match(r"^(.*) release ([0-9](\.[0-9])*)( \(.*\))?.*$",
                              release_info[0].strip())
                 if m:
-                    distro, version, _ = m.groups()
+                    distro, version, _, _ = m.groups()
                     if CENTOS_DISTRO_IDENTIFIER not in distro:
                         LOG.debug(
                             "Distro does not appear to be a CentOS: %s", distro)
                         return {}
 
+                    distribution_name = CENTOS_DISTRO_IDENTIFIER
+                    if CENTOS_STREAM_DISTRO_IDENTIFIER in distro:
+                        distribution_name = CENTOS_STREAM_DISTRO_IDENTIFIER
                     info = {
                         "os_type": constants.OS_TYPE_LINUX,
-                        "distribution_name": CENTOS_DISTRO_IDENTIFIER,
+                        "distribution_name": distribution_name,
                         "release_version": version,
                         "friendly_release_name": "%s Version %s" % (
-                            CENTOS_DISTRO_IDENTIFIER, version)}
+                            distribution_name, version)}
         return info

--- a/coriolis/osmorphing/osdetect/manager.py
+++ b/coriolis/osmorphing/osdetect/manager.py
@@ -12,6 +12,7 @@ from coriolis.osmorphing.osdetect import debian
 from coriolis.osmorphing.osdetect import openwrt
 from coriolis.osmorphing.osdetect import oracle
 from coriolis.osmorphing.osdetect import redhat
+from coriolis.osmorphing.osdetect import rocky
 from coriolis.osmorphing.osdetect import suse
 from coriolis.osmorphing.osdetect import ubuntu
 from coriolis.osmorphing.osdetect import windows
@@ -27,6 +28,7 @@ LINUX_OS_DETECTION_TOOLS = [
     openwrt.OpenWRTOSDetectTools,
     oracle.OracleOSDetectTools,
     redhat.RedHatOSDetectTools,
+    rocky.RockyLinuxOSDetectTools,
     suse.SUSEOSDetectTools,
     ubuntu.UbuntuOSDetectTools
 ]

--- a/coriolis/osmorphing/osdetect/rocky.py
+++ b/coriolis/osmorphing/osdetect/rocky.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import re
+
+from oslo_log import log as logging
+from coriolis import constants
+from coriolis.osmorphing.osdetect import base
+
+
+LOG = logging.getLogger(__name__)
+ROCKY_LINUX_DISTRO_IDENTIFIER = "Rocky Linux"
+
+
+class RockyLinuxOSDetectTools(base.BaseLinuxOSDetectTools):
+
+    def detect_os(self):
+        info = {}
+        redhat_release_path = "etc/redhat-release"
+        if self._test_path(redhat_release_path):
+            release_info = self._read_file(
+                redhat_release_path).decode().splitlines()
+            if release_info:
+                m = re.match(r"^(.*) release ([0-9](\.[0-9])*)( \(.*\))?.*$",
+                             release_info[0].strip())
+                if m:
+                    distro, version, _, _ = m.groups()
+                    if ROCKY_LINUX_DISTRO_IDENTIFIER not in distro:
+                        LOG.debug(
+                            "Distro does not appear to be a Rocky Linux: %s",
+                            distro)
+                        return {}
+
+                    info = {
+                        "os_type": constants.OS_TYPE_LINUX,
+                        "distribution_name": ROCKY_LINUX_DISTRO_IDENTIFIER,
+                        "release_version": version,
+                        "friendly_release_name": "%s Version %s" % (
+                            ROCKY_LINUX_DISTRO_IDENTIFIER, version)}
+        return info

--- a/coriolis/osmorphing/rocky.py
+++ b/coriolis/osmorphing/rocky.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from coriolis.osmorphing import centos
+from coriolis.osmorphing.osdetect import rocky as rocky_osdetect
+
+
+ROCKY_LINUX_DISTRO_IDENTIFIER = rocky_osdetect.ROCKY_LINUX_DISTRO_IDENTIFIER
+
+
+class BaseRockyLinuxMorphingTools(centos.BaseCentOSMorphingTools):
+
+    @classmethod
+    def check_os_supported(cls, detected_os_info):
+        if detected_os_info['distribution_name'] != (
+                ROCKY_LINUX_DISTRO_IDENTIFIER):
+            return False
+        return cls._version_supported_util(
+            detected_os_info['release_version'], minimum=8)


### PR DESCRIPTION
This PR will add core support for OSMorphing Tools that support the following Linux distributions: 

- CentOS Stream (any version)
- Oracle Linux 9
- Rocky Linux (>=8)