### PR TITLE
More worker-related fixes

### DIFF
--- a/coriolis/utils.py
+++ b/coriolis/utils.py
@@ -710,7 +710,7 @@ def _write_systemd(ssh, cmdline, svcname, run_as=None, start=True):
                 get_pty=True)
 
     def _correct_selinux_label():
-        cmd = "sudo /sbin/restorecon -v %s" % serviceFilePath
+        cmd = "sudo restorecon -v %s" % serviceFilePath
         try:
             exec_ssh_cmd(ssh, cmd, get_pty=True)
         except exception.CoriolisException:


### PR DESCRIPTION
**Fix hanging SSH command on Ubuntu worker**

When executing `sudo /sbin/xxxx` on a Ubuntu worker machine, sudo will always
ask for a password, even though the user is set as passwordless, and even if
the binary does not exist. This patch removes any trace of `/sbin/xxxx`
sudo commands.

**Rename duplicate VG names**

Duplicate VG names interfere with the OSMorphing process. This patch makes
sure there are no duplicate volume group names before activating them.

