### PR TITLE
added a try-block to catch the SSH error

### DIFF
--- a/coriolis/providers/replicator.py
+++ b/coriolis/providers/replicator.py
@@ -476,7 +476,7 @@ class Replicator(object):
             return ssh
         except paramiko.ssh_exception.SSHException as ex:
             raise exception.CoriolisException(
-                "Failed to setup SSH client: %s" % str(ex))
+                "Failed to setup SSH client: %s" % str(ex)) from ex
 
     def _parse_source_ssh_conn_info(self, conn_info):
         # if we get valid SSH connection info we can

--- a/coriolis/providers/replicator.py
+++ b/coriolis/providers/replicator.py
@@ -16,7 +16,7 @@ import requests
 
 from coriolis import exception
 from coriolis import utils
-
+from coriolis.exception import NotAuthorized
 
 LOG = logging.getLogger(__name__)
 
@@ -470,10 +470,13 @@ class Replicator(object):
         """
         gets a paramiko SSH client
         """
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(**args)
-        return ssh
+        try:
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.connect(**args)
+            return ssh
+        except paramiko.ssh_exception.SSHException as ex:
+            raise NotAuthorized("Failed to setup SSH client: %s" % str(ex))
 
     def _parse_source_ssh_conn_info(self, conn_info):
         # if we get valid SSH connection info we can
@@ -507,6 +510,7 @@ class Replicator(object):
             "password": password,
             "pkey": pkey,
             "port": port,
+            "banner_timeout": CONF.replicator.default_requests_timeout,
         }
         return args
 

--- a/coriolis/providers/replicator.py
+++ b/coriolis/providers/replicator.py
@@ -16,7 +16,6 @@ import requests
 
 from coriolis import exception
 from coriolis import utils
-from coriolis.exception import NotAuthorized
 
 LOG = logging.getLogger(__name__)
 
@@ -476,7 +475,8 @@ class Replicator(object):
             ssh.connect(**args)
             return ssh
         except paramiko.ssh_exception.SSHException as ex:
-            raise NotAuthorized("Failed to setup SSH client: %s" % str(ex))
+            raise exception.CoriolisException(
+                "Failed to setup SSH client: %s" % str(ex))
 
     def _parse_source_ssh_conn_info(self, conn_info):
         # if we get valid SSH connection info we can


### PR DESCRIPTION
The purpose of this PR is to provide a more user-friendly error messages when SSH exceptions are encountered. For example, instead of printing a generic message like "Authentication failed" it's better to provide more context by indicating that the error is related to the SSH client. Also, an optional timeout was added to wait for the SSH banner to be presented.