### PR TITLE
Fix common option register

### DIFF
--- a/coriolis/cmd/__init__.py
+++ b/coriolis/cmd/__init__.py
@@ -5,4 +5,6 @@ import eventlet
 
 from coriolis import conf
 
+
 eventlet.monkey_patch()
+conf.init_common_opts()

--- a/coriolis/conf.py
+++ b/coriolis/conf.py
@@ -3,11 +3,12 @@
 
 from oslo_config import cfg
 
-opts = [
-    cfg.IntOpt('default_requests_timeout',
-               default=60,
-               help='Number of seconds for HTTP request timeouts.'),
-]
 
-CONF = cfg.CONF
-CONF.register_opts(opts)
+def init_common_opts():
+    opts = [
+        cfg.IntOpt('default_requests_timeout',
+                   default=60,
+                   help='Number of seconds for HTTP request timeouts.'),
+    ]
+
+    cfg.CONF.register_opts(opts)


### PR DESCRIPTION
This patch will register common options before starting services, but instead of just importing the `conf` module and let the registering occur implicitly, it calls `conf.init_common_opts` explicitly.