### PR TITLE
Refactor GRUB2 console settings setup for migrated Linux machines

### DIFF
--- a/coriolis/osmorphing/centos.py
+++ b/coriolis/osmorphing/centos.py
@@ -12,6 +12,8 @@ CENTOS_STREAM_DISTRO_IDENTIFIER = centos_detect.CENTOS_STREAM_DISTRO_IDENTIFIER
 
 class BaseCentOSMorphingTools(redhat.BaseRedHatMorphingTools):
 
+    UEFI_GRUB_LOCATION = "/boot/efi/EFI/centos"
+
     @classmethod
     def check_os_supported(cls, detected_os_info):
         supported_oses = [

--- a/coriolis/osmorphing/debian.py
+++ b/coriolis/osmorphing/debian.py
@@ -58,6 +58,9 @@ class BaseDebianMorphingTools(base.BaseLinuxOSMorphingTools):
         self._write_file_sudo("etc/default/grub", cfg.dump())
         self._exec_cmd_chroot("/usr/sbin/update-grub")
 
+    def get_update_grub2_command(self):
+        return "update-grub"
+
     def _compose_interfaces_config(self, nics_info):
         fp = StringIO()
         fp.write(LO_NIC_TPL)

--- a/coriolis/osmorphing/openwrt.py
+++ b/coriolis/osmorphing/openwrt.py
@@ -34,3 +34,6 @@ class BaseOpenWRTMorphingTools(base.BaseLinuxOSMorphingTools):
 
     def set_net_config(self, nics_info, dhcp):
         pass
+
+    def get_update_grub2_command(self):
+        raise NotImplementedError()

--- a/coriolis/osmorphing/rocky.py
+++ b/coriolis/osmorphing/rocky.py
@@ -10,6 +10,8 @@ ROCKY_LINUX_DISTRO_IDENTIFIER = rocky_osdetect.ROCKY_LINUX_DISTRO_IDENTIFIER
 
 class BaseRockyLinuxMorphingTools(centos.BaseCentOSMorphingTools):
 
+    UEFI_GRUB_LOCATION = "/boot/efi/EFI/rocky"
+
     @classmethod
     def check_os_supported(cls, detected_os_info):
         if detected_os_info['distribution_name'] != (


### PR DESCRIPTION
This patch refactors the setup of GRUB2 console settings into `BaseLinuxOSMorphingTools`, so more providers could use it directly.