### PR TITLE
Add more unit tests for `coriolis` main modules

### DIFF
--- a/coriolis/keystone.py
+++ b/coriolis/keystone.py
@@ -95,7 +95,7 @@ def delete_trust(ctxt):
         try:
             client.trusts.delete(ctxt.trust_id)
         except ks_exceptions.NotFound:
-            LOG.debug("Trust id not found: %s", ctxt.trust_id)
+            LOG.warn("Trust id not found: %s", ctxt.trust_id)
         ctxt.trust_id = None
 
 

--- a/coriolis/tests/test_exception.py
+++ b/coriolis/tests/test_exception.py
@@ -1,0 +1,124 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolis import exception
+from coriolis.tests import test_base
+
+
+class ConvertedExceptionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis ConvertedException class."""
+
+    def test__init__(self):
+        result = exception.ConvertedException(
+            code=403, title='Forbidden', explanation='test')
+
+        self.assertEqual(result.code, 403)
+        self.assertEqual(result.title, 'Forbidden')
+        self.assertEqual(result.explanation, 'test')
+
+    def test__init__without_title(self):
+        result = exception.ConvertedException(code=403, explanation='test')
+
+        self.assertEqual(result.code, 403)
+        self.assertEqual(result.title, 'Forbidden')
+        self.assertEqual(result.explanation, 'test')
+
+    def test__init__with_code_not_in_status_reasons(self):
+        result = exception.ConvertedException(code=450, explanation='test')
+
+        self.assertEqual(result.code, 450)
+        self.assertEqual(result.title, 'Unknown Client Error')
+        self.assertEqual(result.explanation, 'test')
+
+
+class CoriolisTestException(exception.CoriolisException):
+    message = "Test message with missing placeholder: %(missing_key)s"
+
+
+class CoriolisExceptionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis CoriolisException class."""
+
+    def test__init__(self):
+        result = exception.CoriolisException()
+
+        self.assertEqual(result.message, 'An unknown exception occurred.')
+        self.assertEqual(result.code, 500)
+        self.assertEqual(result.headers, {})
+        self.assertEqual(result.safe, False)
+
+    def test__init__with_exception_in_kwargs_items(self):
+        kwargs = {'test_key': 'test_value', 'code': 500}
+        kwargs['exc'] = ValueError('Test exception message')
+
+        result = exception.CoriolisException(**kwargs)
+
+        kwargs['exc'] = str(kwargs['exc'])
+
+        self.assertEqual(result.msg, 'An unknown exception occurred.')
+        self.assertEqual(result.kwargs, kwargs)
+
+    def test__init__custom_message_and_kwargs(self):
+        custom_message = 'test-message'
+        kwargs = {'test-key': 'test-value'}
+        result = exception.CoriolisException(custom_message, **kwargs)
+
+        expected_message = custom_message % kwargs
+        expected_kwargs = {'test-key': 'test-value', 'code': 500}
+
+        self.assertEqual(result.msg, expected_message)
+        self.assertEqual(result.kwargs, expected_kwargs)
+
+    @mock.patch.object(exception, 'LOG')
+    @mock.patch.object(exception, 'CONF')
+    def test__init__with_exception_in_string_format(self, mock_conf, mock_log):
+        mock_conf.fatal_exception_format_errors = False
+        kwargs = {'some_key': 'some_value'}
+
+        result = CoriolisTestException(**kwargs)
+
+        self.assertEqual(result.msg, CoriolisTestException.message)
+        mock_log.exception.assert_called_once_with(
+            'Exception in string format operation')
+        expected_calls = [
+            mock.call("%(name)s: %(value)s",
+                      {'name': 'some_key', 'value': 'some_value'}),
+            mock.call("%(name)s: %(value)s", {'name': 'code', 'value': 500})
+        ]
+        mock_log.error.assert_has_calls(expected_calls)
+        self.assertEqual(mock_log.error.call_count, 2)
+
+    @mock.patch.object(exception, 'CONF')
+    def test__init__with_fatal_exception_format_errors(self, mock_conf):
+        mock_conf.fatal_exception_format_errors = True
+        kwargs = {'some_key': 'some_value'}
+
+        self.assertRaises(KeyError, CoriolisTestException, **kwargs)
+
+    def test__init__with_exception_message(self):
+        message = ValueError('Test exception message')
+        result = exception.CoriolisException(message)
+        self.assertEqual(str(result), 'Test exception message')
+
+    @mock.patch.object(exception, 'CONF')
+    def test__unicode__(self, mock_conf):
+        mock_conf.fatal_exception_format_errors = False
+        kwargs = {'missing_key': 'some_value'}
+
+        exception_instance = CoriolisTestException(**kwargs)
+        result = exception_instance.__unicode__()
+        self.assertEqual(
+            result, "Test message with missing placeholder: some_value")
+
+
+class APIExceptionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis APIException class."""
+
+    def test__init__(self):
+        result = exception.APIException(service='test_service')
+        self.assertEqual(result.kwargs['service'], 'test_service')
+
+    def test__init__no_service(self):
+        result = exception.APIException()
+        self.assertEqual(result.kwargs['service'], 'unknown')

--- a/coriolis/tests/test_i18n.py
+++ b/coriolis/tests/test_i18n.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolis import i18n
+from coriolis.tests import test_base
+
+
+class I18nTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis i18n module."""
+
+    @mock.patch('oslo_i18n.enable_lazy')
+    def test_enable_lazy(self, mock_enable_lazy):
+        result = i18n.enable_lazy(True)
+
+        mock_enable_lazy.assert_called_once_with(True)
+        self.assertEqual(result, mock_enable_lazy.return_value)
+
+    @mock.patch('oslo_i18n.translate')
+    def test_translate(self, mock_translate):
+        result = i18n.translate('test_value')
+
+        mock_translate.assert_called_once_with('test_value', None)
+        self.assertEqual(result, mock_translate.return_value)
+
+    @mock.patch('oslo_i18n.get_available_languages')
+    def test_get_available_languages(self, mock_get_available_languages):
+        result = i18n.get_available_languages()
+
+        mock_get_available_languages.assert_called_once_with(i18n.DOMAIN)
+        self.assertEqual(result, mock_get_available_languages.return_value)

--- a/coriolis/tests/test_keystone.py
+++ b/coriolis/tests/test_keystone.py
@@ -1,0 +1,297 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+from unittest import mock
+
+from keystoneauth1 import exceptions as ks_exceptions
+
+from coriolis import exception
+from coriolis import keystone
+from coriolis.tests import test_base
+
+
+class KeystoneTestCase(test_base.CoriolisBaseTestCase):
+    """Collection of tests for the Coriolis Keystone module."""
+
+    def setUp(self):
+        super(KeystoneTestCase, self).setUp()
+        self.ctxt = mock.Mock()
+        self.ctxt.trust_id = None
+        self.ctxt.auth_token = 'test_token'
+        self.ctxt.project_name = 'test_project'
+        self.ctxt.project_domain_name = 'test_domain'
+        self.ctxt.user = 'test_user'
+        self.ctxt.project_id = 'test_project_id'
+        self.ctxt.roles = ['test_role']
+        self.connection_info = {
+            'auth_url': 'test_auth_url',
+            'username': 'test_username',
+            'password': 'test_password',
+            'project_name': 'test_project_name'}
+
+        self.trusts_auth_plugin = mock.Mock()
+        self.trusts_auth_plugin.auth_url = 'test_auth_url'
+        self.trusts_auth_plugin.get_user_id.return_value = 'test_trust_user_id'
+
+        self.auth = mock.Mock()
+        self.session = mock.Mock()
+        self.client = mock.Mock()
+        self.trust = mock.Mock()
+
+        self.trust.id = 'test_trust_id'
+        self.client.trusts.create.return_value = self.trust
+
+    @mock.patch.object(keystone.loading, 'load_auth_from_conf_options')
+    def test_get_trusts_auth_plugin(self, mock_load_auth_from_conf_options):
+        mock_load_auth_from_conf_options.return_value = self.trusts_auth_plugin
+
+        result = keystone._get_trusts_auth_plugin()
+
+        mock_load_auth_from_conf_options.assert_called_once_with(
+            keystone.CONF, keystone.TRUSTEE_CONF_GROUP, trust_id=None)
+        self.assertEqual(result, self.trusts_auth_plugin)
+
+    @mock.patch('coriolis.keystone._get_trusts_auth_plugin')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.kc_v3, 'Client')
+    def test_create_trust(self, mock_client, mock_session,
+                          mock_get_plugin_loader, mock_get_trusts_auth_plugin):
+        mock_get_trusts_auth_plugin.return_value = self.trusts_auth_plugin
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+        mock_client.return_value = self.client
+
+        keystone.create_trust(self.ctxt)
+
+        mock_get_trusts_auth_plugin.assert_called_once_with()
+        mock_get_plugin_loader.assert_called_once_with("v3token")
+        mock_get_plugin_loader.return_value.\
+            load_from_options.assert_called_once_with(
+                auth_url=self.trusts_auth_plugin.auth_url,
+                token=self.ctxt.auth_token,
+                project_name=self.ctxt.project_name,
+                project_domain_name=self.ctxt.project_domain_name)
+        mock_session.assert_called_once_with(
+            auth=self.auth, verify=not keystone.CONF.keystone.allow_untrusted)
+        mock_client.assert_called_once_with(session=self.session)
+        self.client.trusts.create.assert_called_once_with(
+            trustor_user=self.ctxt.user,
+            trustee_user=self.trusts_auth_plugin.get_user_id.return_value,
+            project=self.ctxt.project_id,
+            impersonation=True,
+            role_names=self.ctxt.roles)
+        self.assertEqual(self.ctxt.trust_id, self.trust.id)
+
+    def test_create_trust_with_existing_trust_id(self):
+        self.ctxt.trust_id = 'test_trust_id'
+        keystone.create_trust(self.ctxt)
+        self.assertEqual(self.ctxt.trust_id, 'test_trust_id')
+
+    @mock.patch('coriolis.keystone._get_trusts_auth_plugin')
+    @mock.patch.object(keystone.kc_v3, 'Client')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    @mock.patch.object(keystone.ks_session, 'Session')
+    def test_create_trust_unauthorized_exception(self,
+                                                 mock_session,
+                                                 mock_get_plugin_loader,
+                                                 mock_client,
+                                                 mock_get_trusts_auth_plugin):
+        mock_get_trusts_auth_plugin.return_value = self.trusts_auth_plugin
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+        mock_client.return_value = self.client
+        self.trusts_auth_plugin.get_user_id.side_effect = \
+            ks_exceptions.Unauthorized
+
+        self.assertRaises(exception.NotAuthorized, keystone.create_trust,
+                          self.ctxt)
+
+    @mock.patch('coriolis.keystone._get_trusts_auth_plugin')
+    @mock.patch.object(keystone.kc_v3, 'Client')
+    @mock.patch.object(keystone.ks_session, 'Session')
+    def test_delete_trust(self, mock_session, mock_client,
+                          mock_get_trusts_auth_plugin):
+        mock_get_trusts_auth_plugin.return_value = self.trusts_auth_plugin
+        self.ctxt.trust_id = 'test_trust_id'
+        mock_session.return_value = self.session
+        mock_client.return_value = self.client
+
+        keystone.delete_trust(self.ctxt)
+
+        mock_get_trusts_auth_plugin.assert_called_once_with('test_trust_id')
+        mock_session.assert_called_once_with(
+            auth=self.trusts_auth_plugin, verify=True)
+        mock_client.assert_called_once_with(session=self.session)
+        self.client.trusts.delete.assert_called_once_with('test_trust_id')
+        self.assertEqual(self.ctxt.trust_id, None)
+
+    @mock.patch('coriolis.keystone._get_trusts_auth_plugin')
+    @mock.patch.object(keystone.kc_v3, 'Client')
+    @mock.patch.object(keystone.ks_session, 'Session')
+    def test_delete_trust_with_not_found_exception(
+            self, mock_session, mock_client, mock_get_trusts_auth_plugin):
+        mock_get_trusts_auth_plugin.return_value = self.trusts_auth_plugin
+        self.ctxt.trust_id = 'test_trust_id'
+        mock_session.return_value = self.session
+        mock_client.return_value = self.client
+        self.client.trusts.delete.side_effect = ks_exceptions.NotFound
+
+        with self.assertLogs('coriolis.keystone', level=logging.WARN):
+            keystone.delete_trust(self.ctxt)
+
+        mock_get_trusts_auth_plugin.assert_called_once_with('test_trust_id')
+        mock_session.assert_called_once_with(
+            auth=self.trusts_auth_plugin, verify=True)
+        mock_client.assert_called_once_with(session=self.session)
+        self.client.trusts.delete.assert_called_once_with('test_trust_id')
+        self.assertEqual(self.ctxt.trust_id, None)
+
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session(self, mock_get_plugin_loader,
+                                     mock_session):
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+
+        result = keystone.create_keystone_session(self.ctxt,
+                                                  self.connection_info)
+
+        mock_get_plugin_loader.assert_called_once_with("password")
+        mock_get_plugin_loader.return_value.\
+            load_from_options.assert_called_once_with(
+                auth_url=self.connection_info['auth_url'],
+                username=self.connection_info['username'],
+                password=self.connection_info['password'],
+                project_name=self.connection_info['project_name'])
+
+        mock_session.assert_called_once_with(
+            auth=self.auth, verify=not keystone.CONF.keystone.allow_untrusted)
+        self.assertEqual(result, self.session)
+
+    @mock.patch('coriolis.keystone._get_trusts_auth_plugin')
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session_with_trust_id_no_username(
+            self, mock_get_plugin_loader, mock_session,
+            mock_get_trusts_auth_plugin):
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+        mock_get_trusts_auth_plugin.return_value = self.trusts_auth_plugin
+
+        self.ctxt.trust_id = 'test_trust_id'
+        self.ctxt.username = None
+        self.connection_info = {}
+
+        result = keystone.create_keystone_session(self.ctxt,
+                                                  self.connection_info)
+
+        mock_get_trusts_auth_plugin.assert_called_once_with('test_trust_id')
+        mock_session.assert_called_once_with(
+            auth=self.trusts_auth_plugin, verify=True)
+        self.assertEqual(result, mock_session.return_value)
+
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session_with_connection_info_no_username(
+            self, mock_get_plugin_loader, mock_session):
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+
+        connection_info = self.connection_info.copy()
+        connection_info.pop('username')
+
+        result = keystone.create_keystone_session(self.ctxt,
+                                                  connection_info)
+
+        mock_get_plugin_loader.assert_called_once_with("token")
+        mock_get_plugin_loader.return_value.\
+            load_from_options.assert_called_once_with(
+                auth_url=self.connection_info['auth_url'],
+                token=self.ctxt.auth_token,
+                project_name=self.connection_info['project_name'])
+
+        mock_session.assert_called_once_with(
+            auth=self.auth, verify=not keystone.CONF.keystone.allow_untrusted)
+        self.assertEqual(result, self.session)
+
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session_with_connection_info_no_auth_url(
+            self, mock_get_plugin_loader, mock_session):
+        keystone.CONF.keystone.auth_url = None
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+
+        connection_info = self.connection_info.copy()
+        connection_info.pop('auth_url')
+
+        self.assertRaises(exception.CoriolisException,
+                          keystone.create_keystone_session,
+                          self.ctxt, connection_info)
+
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session_version_3(self, mock_get_plugin_loader,
+                                               mock_session):
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+        self.connection_info['identity_api_version'] = 3
+
+        result = keystone.create_keystone_session(self.ctxt,
+                                                  self.connection_info)
+
+        mock_get_plugin_loader.assert_called_once_with("v3password")
+        mock_get_plugin_loader.return_value.\
+            load_from_options.assert_called_once_with(
+                auth_url=self.connection_info['auth_url'],
+                username=self.connection_info['username'],
+                password=self.connection_info['password'],
+                project_name=self.connection_info['project_name'],
+                project_domain_name=self.ctxt.project_domain_name,
+                project_domain_id=self.ctxt.project_domain_id,
+                user_domain_name=self.ctxt.user_domain_name,
+                user_domain_id=self.ctxt.user_domain_id)
+        mock_session.assert_called_once_with(
+            auth=self.auth, verify=not keystone.CONF.keystone.allow_untrusted)
+        self.assertEqual(result, self.session)
+
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session_no_project_domain_name_and_id(
+            self, mock_get_plugin_loader, mock_session):
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+
+        self.connection_info['identity_api_version'] = 3
+        self.ctxt.project_domain_name = None
+        self.ctxt.project_domain_id = None
+
+        self.assertRaises(exception.CoriolisException,
+                          keystone.create_keystone_session,
+                          self.ctxt, self.connection_info)
+
+    @mock.patch.object(keystone.ks_session, 'Session')
+    @mock.patch.object(keystone.loading, 'get_plugin_loader')
+    def test_create_keystone_session_no_user_domain_name_and_id(
+            self, mock_get_plugin_loader, mock_session):
+        mock_get_plugin_loader.return_value.\
+            load_from_options.return_value = self.auth
+        mock_session.return_value = self.session
+
+        self.connection_info['identity_api_version'] = 3
+        self.ctxt.user_domain_name = None
+        self.ctxt.user_domain_id = None
+
+        self.assertRaises(exception.CoriolisException,
+                          keystone.create_keystone_session,
+                          self.ctxt, self.connection_info)

--- a/coriolis/tests/test_policy.py
+++ b/coriolis/tests/test_policy.py
@@ -1,0 +1,130 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolis import policy
+from coriolis.tests import test_base
+
+
+class PolicyTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis policy module."""
+
+    @mock.patch.object(policy, '_ENFORCER')
+    def test_reset(self, mock_enforcer):
+        result = policy.reset()
+
+        mock_enforcer.clear.assert_called_once_with()
+        self.assertEqual(result, None)
+        self.assertEqual(policy._ENFORCER, None)
+
+    @mock.patch('oslo_policy.policy.Enforcer')
+    @mock.patch.object(policy, 'register_rules')
+    @mock.patch.object(policy, 'CONF')
+    def test_init(self, mock_conf, mock_register_rules, mock_policy_enforcer):
+        mock_enforcer_instance = mock.Mock()
+        mock_policy_enforcer.return_value = mock_enforcer_instance
+
+        with mock.patch('coriolis.policy._ENFORCER', None):
+            result = policy.init()
+
+        mock_policy_enforcer.assert_called_once_with(mock_conf)
+        mock_register_rules.assert_called_once_with(mock_enforcer_instance)
+        mock_enforcer_instance.load_rules.assert_called_once_with()
+        self.assertEqual(result, None)
+
+    @mock.patch.object(policy, '_ENFORCER')
+    def test_init_already_initialized(self, mock_enforcer):
+        mock_enforcer_instance = mock.Mock()
+        mock_enforcer.return_value = mock_enforcer_instance
+
+        result = policy.init()
+        self.assertEqual(result, None)
+
+    @mock.patch.object(policy, 'itertools')
+    def test_register_rules(self, mock_itertools):
+        mock_enforcer = mock.Mock()
+        mock_enforcer.register_defaults.return_value = ['rule1', 'rule2']
+        mock_itertools.chain.return_value = ['rule1', 'rule2', 'rule3']
+
+        result = policy.register_rules(mock_enforcer)
+
+        mock_enforcer.register_defaults.assert_called_once_with(
+            ['rule1', 'rule2', 'rule3'])
+        self.assertEqual(result, None)
+
+    @mock.patch.object(policy, 'init')
+    def test_get_enforcer(self, mock_init):
+        mock_enforcer = mock.Mock()
+        policy._ENFORCER = mock_enforcer
+
+        result = policy.get_enforcer()
+
+        mock_init.assert_called_once_with()
+        self.assertEqual(result, mock_enforcer)
+
+    @mock.patch.object(policy, 'init')
+    def test_get_enforcer_not_initialized(self, mock_init):
+        policy._ENFORCER = None
+
+        result = policy.get_enforcer()
+
+        self.assertEqual(result, None)
+        mock_init.assert_called_once_with()
+
+    @mock.patch.object(policy, '_ENFORCER')
+    def test_check_policy_for_context(self, mock_enforcer):
+        mock_enforcer.authorize.return_value = True
+
+        mock_context = mock.Mock()
+        mock_context.to_policy_values.return_value = 'test-credentials'
+
+        result = policy.check_policy_for_context(
+            mock_context, 'rule', 'target')
+
+        self.assertEqual(result, True)
+        mock_enforcer.authorize.assert_called_once_with(
+            'rule', 'target', 'test-credentials', do_raise=True, exc=mock.ANY,
+            action='rule')
+
+    @mock.patch.object(policy, '_ENFORCER')
+    def test_check_policy_for_context_do_not_raise(self, mock_enforcer):
+        mock_enforcer.authorize.return_value = False
+
+        mock_context = mock.Mock()
+        mock_context.to_policy_values.return_value = 'test-credentials'
+
+        result = policy.check_policy_for_context(
+            mock_context, 'rule', 'target', do_raise=False)
+
+        mock_enforcer.authorize.assert_called_once_with(
+            'rule', 'target', 'test-credentials', do_raise=False, exc=mock.ANY,
+            action='rule')
+        self.assertEqual(result, False)
+
+    @mock.patch.object(policy, '_ENFORCER')
+    def test_check_policy_for_context_not_authorized(self, mock_enforcer):
+        mock_enforcer.authorize.side_effect = (
+            policy.exception.PolicyNotAuthorized)
+
+        mock_context = mock.Mock()
+        mock_context.to_policy_values.return_value = 'test-credentials'
+
+        self.assertRaises(
+            policy.exception.PolicyNotAuthorized,
+            policy.check_policy_for_context, mock_context, 'rule', 'target')
+
+        mock_enforcer.authorize.assert_called_once_with(
+            'rule', 'target', 'test-credentials', do_raise=True, exc=mock.ANY,
+            action='rule')
+
+    @mock.patch.object(policy, '_ENFORCER')
+    def test_check_policy_for_context_custom_exception(self, mock_enforcer):
+        mock_enforcer.authorize.side_effect = ValueError
+
+        mock_context = mock.Mock()
+        mock_context.to_policy_values.return_value = 'test-credentials'
+
+        self.assertRaises(
+            ValueError, policy.check_policy_for_context, mock_context,
+            'rule', 'target', exc=ValueError)


### PR DESCRIPTION
This PR adds more unit testing for the following modules:
 * `exception.py`
 * `i18n.py`
 * `keystone.py`
 * `policy.py`