### PR TITLE
Add more unit tests for `coriolis` main modules

### DIFF
--- a/coriolis/tests/test_rpc.py
+++ b/coriolis/tests/test_rpc.py
@@ -1,0 +1,224 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolis import context
+from coriolis import rpc
+from coriolis.tests import test_base
+
+
+class RequestContextSerializerTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis RequestContextSerializer class."""
+
+    def setUp(self):
+        super(RequestContextSerializerTestCase, self).setUp()
+        self.base = mock.Mock()
+        self.ctxt = mock.Mock()
+        self.entity = {'foo': 'bar'}
+        self.serializer = rpc.RequestContextSerializer(self.base)
+
+    def test_serialize_entity_base_none(self):
+        serializer = rpc.RequestContextSerializer(None)
+        result = serializer.serialize_entity(self.ctxt, self.entity)
+        self.assertEqual(result, self.entity)
+
+    def test_serialize_entity_base_not_none(self):
+        result = self.serializer.serialize_entity(self.ctxt, self.entity)
+        self.base.serialize_entity.assert_called_once_with(self.ctxt,
+                                                           self.entity)
+        self.assertEqual(result, self.base.serialize_entity.return_value)
+
+    def test_deserialize_entity_base_none(self):
+        serializer = rpc.RequestContextSerializer(None)
+        result = serializer.deserialize_entity(self.ctxt, self.entity)
+        self.assertEqual(result, self.entity)
+
+    def test_deserialize_entity_base_not_none(self):
+        result = self.serializer.deserialize_entity(self.ctxt, self.entity)
+        self.base.deserialize_entity.assert_called_once_with(self.ctxt,
+                                                             self.entity)
+        self.assertEqual(result, self.base.deserialize_entity.return_value)
+
+    def test_serialize_context(self):
+        result = self.serializer.serialize_context(self.ctxt)
+        self.ctxt.to_dict.assert_called_once_with()
+        self.assertEqual(result, self.ctxt.to_dict.return_value)
+
+    def test_deserialize_context(self):
+        ctxt_dict = {'foo': 'bar'}
+        with mock.patch.object(
+            context.RequestContext, 'from_dict') as mock_from_dict:
+            result = self.serializer.deserialize_context(ctxt_dict)
+
+            mock_from_dict.assert_called_once_with(ctxt_dict)
+            self.assertEqual(result, mock_from_dict.return_value)
+
+
+class RpcTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis RPC module."""
+
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    def test_get_transport(self, mock_get_transport):
+        result = rpc._get_transport()
+
+        mock_get_transport.assert_called_once_with(
+            mock.ANY, mock.ANY, allowed_remote_exmods=rpc.ALLOWED_EXMODS)
+        self.assertEqual(result, mock_get_transport.return_value)
+
+    @mock.patch('coriolis.rpc.messaging.get_rpc_server')
+    @mock.patch('coriolis.rpc._get_transport')
+    @mock.patch('coriolis.rpc.RequestContextSerializer')
+    def test_get_server(self, mock_context_serializer, mock_get_transport,
+                        mock_get_rpc_server):
+        target = mock.Mock()
+        endpoints = mock.Mock()
+        serializer = mock.Mock()
+        mock_context_serializer.return_value = serializer
+
+        result = rpc.get_server(target, endpoints, serializer)
+
+        mock_context_serializer.assert_called_once_with(serializer)
+        mock_get_rpc_server.assert_called_once_with(
+            mock_get_transport.return_value, target, endpoints,
+            executor='eventlet', serializer=serializer)
+        self.assertEqual(result, mock_get_rpc_server.return_value)
+
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    def test_init(self, mock_get_transport):
+        rpc._TRANSPORT = None
+        result = rpc.init()
+
+        mock_get_transport.assert_called_once()
+        self.assertEqual(result, mock_get_transport.return_value)
+        self.assertEqual(rpc._TRANSPORT, mock_get_transport.return_value)
+
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    def test_init_already_initialized(self, mock_get_transport):
+        rpc._TRANSPORT = mock.Mock()
+        result = rpc.init()
+        self.assertEqual(result, rpc._TRANSPORT)
+        mock_get_transport.assert_not_called()
+
+
+class BaseRPCClientTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis BaseRPCClient class."""
+
+    def setUp(self):
+        super(BaseRPCClientTestCase, self).setUp()
+        self.target = mock.Mock()
+        self.timeout = 60
+        self.serializer = mock.Mock()
+        self.method = mock.Mock()
+        self.host = mock.Mock()
+        self.args = {'foo': 'bar'}
+        self.client = rpc.BaseRPCClient(self.target, timeout=self.timeout)
+
+    def test_init(self):
+        with mock.patch.object(rpc, 'RequestContextSerializer') as mock_ser:
+            client = rpc.BaseRPCClient(self.target, timeout=self.timeout,
+                                       serializer=self.serializer)
+            mock_ser.assert_called_once_with(self.serializer)
+            self.assertEqual(client._serializer, mock_ser.return_value)
+        self.assertEqual(client._target, self.target)
+        self.assertEqual(client._timeout, self.timeout)
+        self.assertEqual(client._transport_conn, None)
+
+    def test_init_timeout_is_None(self):
+        with mock.patch.object(rpc, 'RequestContextSerializer') as mock_ser:
+            client = rpc.BaseRPCClient(self.target, timeout=None,
+                                       serializer=self.serializer)
+            mock_ser.assert_called_once_with(self.serializer)
+            self.assertEqual(client._serializer, mock_ser.return_value)
+        self.assertEqual(client._target, self.target)
+        self.assertEqual(client._timeout,
+                         rpc.CONF.default_messaging_timeout)
+        self.assertEqual(client._transport_conn, None)
+
+    def test_repr(self):
+        result = self.client.__repr__()
+        self.assertEqual(result, "<RPCClient(target=%s, timeout=%s)>" % (
+            self.target, self.timeout))
+
+    @mock.patch.object(rpc, '_get_transport')
+    def test_transport_property_when_transport_is_None(self,
+                                                       mock_get_transport):
+        with mock.patch.object(rpc, '_TRANSPORT', None):
+            result = self.client._transport
+
+        mock_get_transport.assert_called_once()
+        self.assertEqual(result, mock_get_transport.return_value)
+
+    @mock.patch.object(rpc, '_get_transport')
+    def test_transport_property_when_transport_conn_is_not_None(
+            self, mock_get_transport):
+        with mock.patch.object(rpc, '_TRANSPORT', None):
+            self.client._transport_conn = mock.Mock()
+            result = self.client._transport
+
+        mock_get_transport.assert_not_called()
+        self.assertEqual(result, self.client._transport_conn)
+
+    @mock.patch.object(rpc, '_TRANSPORT')
+    def test_transport_property_when_transport_is_not_None(self,
+                                                           mock_transport):
+        result = self.client._transport
+
+        self.assertEqual(result, mock_transport)
+        self.assertEqual(self.client._transport_conn, None)
+
+    @mock.patch('oslo_messaging.RPCClient')
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    def test_rpc_client(self, mock_get_transport, mock_rpc_client):
+        mock_get_transport.return_value = mock.MagicMock()
+        result = self.client._rpc_client()
+
+        mock_rpc_client.assert_called_once_with(
+            self.client._transport, self.client._target,
+            serializer=self.client._serializer, timeout=self.client._timeout)
+        self.assertEqual(result, mock_rpc_client.return_value)
+
+    def test_call(self):
+        with mock.patch('coriolis.rpc.BaseRPCClient._rpc_client') as rpc_mock:
+            result = self.client._call(mock.sentinel.ctxt, self.method,
+                                       **self.args)
+
+            rpc_mock.assert_called_once()
+            rpc_mock.return_value.call.assert_called_once_with(
+                mock.sentinel.ctxt, self.method, **self.args)
+            self.assertEqual(
+                result, rpc_mock.return_value.call.return_value)
+
+    def test_call_on_host(self):
+        with mock.patch('coriolis.rpc.BaseRPCClient._rpc_client') as rpc_mock:
+            result = self.client._call_on_host(self.host, mock.sentinel.ctxt,
+                                               self.method, **self.args)
+
+            rpc_mock.assert_called_once()
+            rpc_mock.return_value.prepare.assert_called_once_with(
+                server=self.host)
+            rpc_mock.return_value.prepare.return_value.call.\
+                assert_called_once_with(mock.sentinel.ctxt, self.method,
+                                        **self.args)
+            self.assertEqual(result, rpc_mock.return_value.prepare.
+                             return_value.call.return_value)
+
+    def test_cast(self):
+        with mock.patch('coriolis.rpc.BaseRPCClient._rpc_client') as rpc_mock:
+            self.client._cast(mock.sentinel.ctxt, self.method, **self.args)
+
+            rpc_mock.assert_called_once()
+            rpc_mock.return_value.cast.assert_called_once_with(
+                mock.sentinel.ctxt, self.method, **self.args)
+
+    def test_cast_for_host(self):
+        with mock.patch('coriolis.rpc.BaseRPCClient._rpc_client') as rpc_mock:
+            self.client._cast_for_host(self.host, mock.sentinel.ctxt,
+                                       self.method, **self.args)
+
+            rpc_mock.assert_called_once()
+            rpc_mock.return_value.prepare.assert_called_once_with(
+                server=self.host)
+            rpc_mock.return_value.prepare.return_value.cast.\
+                assert_called_once_with(mock.sentinel.ctxt, self.method,
+                                        **self.args)

--- a/coriolis/tests/test_schemas.py
+++ b/coriolis/tests/test_schemas.py
@@ -2,11 +2,13 @@
 # All Rights Reserved.
 
 import json
+import logging
+from unittest import mock
 
 import jinja2
 import jsonschema
-from unittest import mock
 
+from coriolis import exception
 from coriolis import schemas
 from coriolis.tests import test_base
 
@@ -66,6 +68,40 @@ class SchemasTestCase(test_base.CoriolisBaseTestCase):
 
         self.assertEqual(res, test_loaded_schema)
 
+    @mock.patch.object(jinja2, 'Environment')
+    @mock.patch.object(jinja2, 'PackageLoader')
+    def test_get_schema_parent_package_exists(self, mock_loader, mock_environ):
+        test_schema_name = 'test.schema.name'
+        test_package_name = 'test.package.name'
+
+        mock_template = mock.MagicMock()
+        mock_template.render.return_value = '{}'
+
+        mock_environ.return_value.get_template.return_value = mock_template
+
+        mock_loader.side_effect = [ValueError(), mock.MagicMock()]
+
+        schemas.get_schema(test_package_name, test_schema_name)
+
+        parent_package = "test.package"
+        mock_loader.assert_has_calls([
+            mock.call(test_package_name, schemas.DEFAULT_SCHEMAS_DIRECTORY),
+            mock.call(parent_package, schemas.DEFAULT_SCHEMAS_DIRECTORY)])
+
+    @mock.patch.object(jinja2, 'PackageLoader')
+    def test_get_schema_parent_package_not_exists(self, mock_loader):
+        test_schema_name = 'test.schema.name'
+        test_package_name = 'testpackage'
+
+        mock_loader.side_effect = ValueError()
+
+        self.assertRaises(
+            ValueError, schemas.get_schema, test_package_name,
+            test_schema_name)
+
+        mock_loader.assert_called_once_with(
+            test_package_name, schemas.DEFAULT_SCHEMAS_DIRECTORY)
+
     @mock.patch.object(jsonschema, 'validate')
     def test_validate_value(self, mock_validate):
         test_value = mock.sentinel.test_value
@@ -90,3 +126,28 @@ class SchemasTestCase(test_base.CoriolisBaseTestCase):
         mock_loads.assert_called_once_with(test_string)
         mock_validate.assert_called_once_with(
             test_value, test_schema, format_checker=None)
+
+    @mock.patch.object(jsonschema, 'validate')
+    def test_validate_value_raises_on_error(self, mock_validate):
+        test_value = mock.sentinel.test_value
+        test_schema = mock.sentinel.test_schema
+
+        mock_validate.side_effect = jsonschema.exceptions.ValidationError(
+            'Test Error')
+
+        self.assertRaises(
+            exception.SchemaValidationException, schemas.validate_value,
+            test_value, test_schema, raise_on_error=True)
+
+    @mock.patch.object(jsonschema, 'validate')
+    def test_validate_value_no_raise_on_error(self, mock_validate):
+        test_value = mock.sentinel.test_value
+        test_schema = mock.sentinel.test_schema
+
+        mock_validate.side_effect = jsonschema.exceptions.ValidationError(
+            'Test Error')
+
+        with self.assertLogs('coriolis.schemas', level=logging.WARN):
+            result = schemas.validate_value(test_value, test_schema,
+                                            raise_on_error=False)
+        self.assertEqual(result, False)

--- a/coriolis/tests/test_secrets.py
+++ b/coriolis/tests/test_secrets.py
@@ -1,0 +1,72 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import json
+from unittest import mock
+
+from barbicanclient import client as barbican_client
+import keystoneauth1
+
+from coriolis import keystone
+from coriolis import secrets
+from coriolis.tests import test_base
+
+
+class SecretsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis secrets module."""
+
+    @mock.patch.object(keystone, 'create_keystone_session')
+    @mock.patch.object(barbican_client, 'Client')
+    def test_get_barbican_secret_payload(self, mock_client, mock_session):
+        mock_session.return_value = mock.sentinel.session
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = mock.sentinel.payload
+        mock_barbican = mock.MagicMock()
+        mock_barbican.secrets.get.return_value = mock_secret
+        mock_client.return_value = mock_barbican
+
+        result = secrets._get_barbican_secret_payload(
+            mock.sentinel.ctxt, mock.sentinel.secret_ref)
+
+        self.assertEqual(mock.sentinel.payload, result)
+        mock_session.assert_called_once_with(mock.sentinel.ctxt)
+        mock_client.assert_called_once_with(session=mock.sentinel.session)
+        mock_barbican.secrets.get.assert_called_once_with(
+            mock.sentinel.secret_ref)
+
+    @mock.patch.object(secrets, '_get_barbican_secret_payload')
+    def test_get_secret_success(self, mock_get_payload):
+        mock_get_payload.return_value = json.dumps({'key': 'value'})
+
+        result = secrets.get_secret(mock.sentinel.ctxt,
+                                    mock.sentinel.secret_ref)
+
+        self.assertEqual({'key': 'value'}, result)
+        mock_get_payload.assert_called_once_with(
+            mock.sentinel.ctxt, mock.sentinel.secret_ref)
+
+    @mock.patch.object(secrets, '_get_barbican_secret_payload')
+    def test_get_secret_unauthorized(self, mock_get_payload):
+        mock_ctxt = mock.MagicMock()
+        mock_get_payload.side_effect = [
+            keystoneauth1.exceptions.http.Unauthorized,
+            json.dumps({'key': 'value'})]
+
+        with mock.patch('copy.deepcopy', side_effect=lambda func: func):
+            result = secrets.get_secret(mock_ctxt, mock.sentinel.secret_ref)
+
+        self.assertEqual({'key': 'value'}, result)
+        self.assertEqual(2, mock_get_payload.call_count)
+        self.assertEqual(mock_ctxt.trust_id, None)
+        mock_get_payload.assert_called_with(
+            mock_ctxt, mock.sentinel.secret_ref)
+
+    @mock.patch.object(secrets, '_get_barbican_secret_payload')
+    def test_get_secret_raises_value_error(self, mock_get_payload):
+        mock_get_payload.side_effect = ValueError("Test exception")
+
+        self.assertRaises(ValueError, secrets.get_secret, mock.sentinel.ctxt,
+                          mock.sentinel.secret_ref)
+
+        mock_get_payload.assert_called_once_with(
+            mock.sentinel.ctxt, mock.sentinel.secret_ref)

--- a/coriolis/tests/test_service.py
+++ b/coriolis/tests/test_service.py
@@ -1,0 +1,281 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+import os
+from unittest import mock
+
+import ddt
+
+from coriolis import service
+from coriolis.tests import test_base
+
+
+@ddt.ddt
+class ServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Service class."""
+
+    @ddt.data(
+        (['--worker-process-count', '5'], 5, [], False),
+        (['--worker-process-count', '10'], 10, [], False),
+        (['--worker-process-count', '15'], 15, [], False),
+        (['--worker-process-count', '20'], 20, [], False),
+        ([], None, [], False),
+        (['--worker-process-count', '5', '--unknown-arg'], 5,
+         ['--unknown-arg'], False),
+        (['--worker-process-count', '-5'], None, None, True),
+        (['--worker-process-count', '0'], None, None, True),
+        (['--worker-process-count', 'not-a-number'], None, None, True)
+    )
+    @ddt.unpack
+    def test_get_worker_count_from_args(self, input_args, expected_count,
+                                        expected_unknown_args,
+                                        expect_exception):
+        if expect_exception:
+            self.assertRaises(SystemExit, service.get_worker_count_from_args,
+                              input_args)
+        else:
+            worker_count, unknown_args = service.get_worker_count_from_args(
+                input_args)
+            self.assertEqual(worker_count, expected_count)
+            self.assertEqual(unknown_args, expected_unknown_args)
+
+    @ddt.data(
+        ({}, False, False, [], logging.WARN),
+        ({'lock_path': ""}, False, False, [], logging.WARN),
+        ({'lock_path': "/path/to/locks"}, False, False, [], logging.WARN),
+        ({'lock_path': "/path/to/locks"}, True, False, [], logging.WARN),
+        ({'lock_path': "/path/to/locks"}, True, True, ['file1', 'file2'],
+         logging.WARN),
+        ({'lock_path': "/path/to/locks"}, True, True, [], logging.INFO),
+    )
+    @ddt.unpack
+    @mock.patch.object(os.path, 'exists')
+    @mock.patch.object(os.path, 'isdir')
+    @mock.patch.object(os, 'listdir')
+    def test_check_locks_dir_empty(self, oslo_concurrency, exists, isdir,
+                                   listdir, expected_log_level, mock_listdir,
+                                   mock_isdir, mock_exists):
+        mock_exists.return_value = exists
+        mock_isdir.return_value = isdir
+        mock_listdir.return_value = listdir
+        with mock.patch.object(service.CONF, 'oslo_concurrency',
+                               oslo_concurrency):
+            with self.assertLogs('coriolis.service', level=expected_log_level):
+                service.check_locks_dir_empty()
+
+
+class WSGIServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis WSGIService class."""
+
+    @mock.patch.object(service.wsgi.Loader, 'load_app')
+    @mock.patch.object(service, 'rpc')
+    @mock.patch.object(service, 'CONF')
+    @mock.patch.object(service.wsgi, 'Server')
+    def test_init(self, mock_server, mock_conf, mock_rpc, mock_load_app):
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_conf.api_migration_listen_port = mock.sentinel.listen_port
+        mock_conf.api_migration_workers = mock.sentinel.workers
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_rpc.init.return_value = mock.sentinel.transport
+
+        wsgi_service = service.WSGIService(mock.sentinel.name, worker_count=10,
+                                           init_rpc=True)
+
+        mock_rpc.init.assert_called_once_with()
+        mock_load_app.assert_called_once_with(mock.sentinel.name)
+        mock_server.assert_called_once_with(
+            mock_conf,
+            mock.sentinel.name,
+            mock_load_app.return_value,
+            host=mock_conf.api_migration_listen,
+            port=mock_conf.api_migration_listen_port)
+        self.assertEqual(wsgi_service._host, mock_conf.api_migration_listen)
+        self.assertEqual(wsgi_service._port,
+                         mock_conf.api_migration_listen_port)
+        self.assertEqual(wsgi_service._workers, 10)
+        self.assertEqual(wsgi_service._app, mock_load_app.return_value)
+        self.assertEqual(wsgi_service._server, mock_server.return_value)
+
+    @mock.patch('platform.system')
+    @mock.patch('oslo_service.wsgi.Server')
+    @mock.patch('oslo_service.wsgi.Loader.load_app')
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    @mock.patch.object(service, 'CONF')
+    def test_init_windows(self, mock_conf, mock_get_transport, mock_load_app,
+                          mock_server, mock_system):
+        mock_system.return_value = "Windows"
+        mock_conf.api_migration_workers = None
+        mock_load_app.return_value = mock.MagicMock()
+        mock_server.return_value = mock.MagicMock()
+        mock_get_transport.return_value = mock.MagicMock()
+
+        result = service.WSGIService('test_service', None, True)
+
+        self.assertEqual(result._workers, 1)
+
+    @mock.patch('platform.system')
+    @mock.patch('oslo_service.wsgi.Server')
+    @mock.patch('oslo_service.wsgi.Loader.load_app')
+    @mock.patch('oslo_concurrency.processutils.get_worker_count')
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    @mock.patch.object(service, 'CONF')
+    def test_init_sets_workers_based_on_system_on_non_windows(
+            self, mock_conf, mock_get_transport, mock_get_worker_count,
+            mock_load_app, mock_server, mock_system):
+        mock_system.return_value = "Linux"
+        mock_conf.api_migration_workers = None
+        mock_load_app.return_value = mock.MagicMock()
+        mock_server.return_value = mock.MagicMock()
+        mock_get_transport.return_value = mock.MagicMock()
+
+        result = service.WSGIService('test_service', None, True)
+
+        self.assertEqual(result._workers, mock_get_worker_count.return_value)
+
+    @mock.patch.object(service, 'CONF')
+    @mock.patch('oslo_service.wsgi.Loader.load_app')
+    @mock.patch('coriolis.rpc.messaging.get_transport')
+    @mock.patch('eventlet.listen')
+    def test_service_methods(self, mock_listen, mock_get_transport,
+                             mock_load_app, mock_conf):
+        mock_conf.api_migration_workers = 10
+        mock_load_app.return_value = mock.MagicMock()
+        mock_get_transport.return_value = mock.MagicMock()
+        mock_socket = mock.MagicMock()
+        mock_socket.getsockname.return_value = ('localhost', 8080)
+        mock_listen.return_value = mock_socket
+
+        result = service.WSGIService('test_service', None, True)
+
+        result._server = mock.MagicMock()
+
+        self.assertEqual(result.get_workers_count(),
+                         mock_conf.api_migration_workers)
+
+        result.start()
+        result._server.start.assert_called_once()
+
+        result.stop()
+        result._server.stop.assert_called_once()
+
+        result.wait()
+        result._server.wait.assert_called_once()
+
+        result.reset()
+        result._server.reset.assert_called_once()
+
+
+class MessagingServiceTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis MessagingService class."""
+
+    @mock.patch.object(service, 'rpc')
+    @mock.patch.object(service, 'CONF')
+    @mock.patch.object(service.messaging, 'Target')
+    @mock.patch.object(service.utils, 'get_hostname')
+    def test_init(self, mock_get_hostname, mock_target, mock_conf, mock_rpc):
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_conf.api_migration_listen_port = mock.sentinel.listen_port
+        mock_conf.api_migration_workers = mock.sentinel.workers
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_rpc.init.return_value = mock.sentinel.transport
+        mock_get_hostname.return_value = mock.sentinel.hostname
+
+        messaging_service = service.MessagingService(
+            mock.sentinel.topic, mock.sentinel.endpoints,
+            mock.sentinel.version, worker_count=10, init_rpc=True)
+
+        mock_rpc.init.assert_called_once_with()
+        mock_target.assert_called_once_with(
+            topic=mock.sentinel.topic,
+            server=mock.sentinel.hostname,
+            version=mock.sentinel.version)
+        mock_rpc.get_server.assert_called_once_with(
+            mock_target.return_value, mock.sentinel.endpoints)
+        self.assertEqual(messaging_service._workers, 10)
+        self.assertEqual(messaging_service._server,
+                         mock_rpc.get_server.return_value)
+
+    @mock.patch('platform.system')
+    @mock.patch.object(service, 'rpc')
+    @mock.patch.object(service, 'CONF')
+    @mock.patch.object(service.messaging, 'Target')
+    @mock.patch.object(service.utils, 'get_hostname')
+    def test_init_windows(self, mock_get_hostname, mock_target, mock_conf,
+                          mock_rpc, mock_system):
+        mock_system.return_value = "Windows"
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_conf.api_migration_listen_port = mock.sentinel.listen_port
+        mock_conf.api_migration_workers = mock.sentinel.workers
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_rpc.init.return_value = mock.sentinel.transport
+        mock_get_hostname.return_value = mock.sentinel.hostname
+
+        messaging_service = service.MessagingService(
+            mock.sentinel.topic, mock.sentinel.endpoints,
+            mock.sentinel.version, worker_count=10, init_rpc=True)
+
+        mock_rpc.init.assert_called_once_with()
+        mock_target.assert_called_once_with(
+            topic=mock.sentinel.topic,
+            server=mock.sentinel.hostname,
+            version=mock.sentinel.version)
+        mock_rpc.get_server.assert_called_once_with(
+            mock_target.return_value, mock.sentinel.endpoints)
+        self.assertEqual(messaging_service._workers, 1)
+        self.assertEqual(messaging_service._server,
+                         mock_rpc.get_server.return_value)
+
+    @mock.patch.object(service, 'rpc')
+    @mock.patch.object(service, 'CONF')
+    @mock.patch.object(service.utils, 'get_hostname')
+    @mock.patch.object(service.processutils, 'get_worker_count')
+    def test_init_with_none_worker_count(self, mock_get_worker_count,
+                                         mock_get_hostname,
+                                         mock_conf, mock_rpc):
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_conf.api_migration_listen_port = mock.sentinel.listen_port
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_rpc.init.return_value = mock.sentinel.transport
+        mock_get_hostname.return_value = mock.sentinel.hostname
+
+        result = service.MessagingService(
+            mock.sentinel.topic, mock.sentinel.endpoints,
+            mock.sentinel.version, worker_count=None, init_rpc=True)
+
+        self.assertEqual(result._workers, mock_get_worker_count.return_value)
+
+    @mock.patch.object(service, 'rpc')
+    @mock.patch.object(service, 'CONF')
+    @mock.patch.object(service.utils, 'get_hostname')
+    @mock.patch.object(service.processutils, 'get_worker_count')
+    def test_service_methods(self, mock_get_worker_count, mock_get_hostname,
+                             mock_conf, mock_rpc):
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_conf.api_migration_listen_port = mock.sentinel.listen_port
+        mock_conf.api_migration_workers = mock.sentinel.worker_count
+        mock_conf.api_migration_listen = mock.sentinel.listen
+        mock_rpc.init.return_value = mock.sentinel.transport
+        mock_get_hostname.return_value = mock.sentinel.hostname
+        mock_get_worker_count.return_value = mock.sentinel.worker_count
+
+        mock_server = mock.MagicMock()
+        mock_rpc.get_server.return_value = mock_server
+
+        result = service.MessagingService(
+            mock.sentinel.topic, mock.sentinel.endpoints,
+            mock.sentinel.version, worker_count=None, init_rpc=True)
+
+        self.assertEqual(result.get_workers_count(),
+                         mock.sentinel.worker_count)
+
+        result.start()
+        mock_server.start.assert_called_once()
+
+        result.stop()
+        mock_server.stop.assert_called_once()
+
+        result.wait()
+
+        result.reset()
+        mock_server.reset.assert_called_once()

--- a/coriolis/tests/test_utils.py
+++ b/coriolis/tests/test_utils.py
@@ -1,0 +1,1395 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import datetime
+import hashlib
+import json
+import logging
+import os
+import socket
+from unittest import mock
+import uuid
+
+import ddt
+from webob import exc
+
+from coriolis import constants
+from coriolis import exception
+from coriolis.tests import test_base
+from coriolis.tests import testutils
+from coriolis import utils
+
+
+class CoriolisTestException(Exception):
+    pass
+
+
+@ddt.ddt
+class UtilsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis utils module."""
+
+    def setUp(self):
+        super(UtilsTestCase, self).setUp()
+        self.mock_func = mock.Mock()
+        self.mock_ssh = mock.Mock()
+        self.mock_sftp = mock.Mock()
+        self.mock_file = mock.Mock()
+        self.mock_conn = mock.Mock()
+        self.mock_stdout = mock.Mock()
+        self.mock_process = mock.Mock()
+
+    @mock.patch('oslo_log.log.setup')
+    def test_setup_logging(self, mock_setup):
+        utils.setup_logging()
+        mock_setup.assert_called_once_with(utils.CONF, 'coriolis')
+
+    @mock.patch.object(utils, 'get_exception_details')
+    def test_ignore_exceptions(self, mock_get_details):
+        mock_get_details.return_value = 'Test exception details'
+        self.mock_func.side_effect = Exception
+
+        with self.assertLogs('coriolis.utils', level=logging.WARN):
+            utils.ignore_exceptions(self.mock_func)()
+
+        mock_get_details.assert_called_once_with()
+
+    def test_get_single_result_empty_list(self):
+        self.assertRaises(KeyError, utils.get_single_result, [])
+
+    def test_get_single_result_multiple_elements(self):
+        self.assertRaises(KeyError, utils.get_single_result, [1, 2])
+
+    def test_get_single_result_single_element(self):
+        result = utils.get_single_result([1])
+        self.assertEqual(result, 1)
+
+    def test_retry_on_error_no_exception(self):
+        result = utils.retry_on_error(
+            max_attempts=5, sleep_seconds=0,
+            terminal_exceptions=[])(self.mock_func)(
+                mock.sentinel.arg1, kwarg1=mock.sentinel.kwarg1)
+
+        self.assertEqual(result, self.mock_func.return_value)
+        self.assertEqual(self.mock_func.call_count, 1)
+        self.mock_func.assert_called_with(
+            mock.sentinel.arg1, kwarg1=mock.sentinel.kwarg1)
+
+    def test_retry_on_error_exception_keyboard_interrupt(self):
+        self.mock_func.side_effect = KeyboardInterrupt
+
+        self.assertRaises(KeyboardInterrupt, utils.retry_on_error(
+            max_attempts=5, sleep_seconds=0,
+            terminal_exceptions=[])(self.mock_func))
+
+        self.assertEqual(self.mock_func.call_count, 1)
+
+    def test_retry_on_error_terminal_exception(self):
+        self.mock_func.side_effect = CoriolisTestException
+
+        self.assertRaises(CoriolisTestException, utils.retry_on_error(
+            max_attempts=5, sleep_seconds=0,
+            terminal_exceptions=[CoriolisTestException])(self.mock_func))
+
+        self.assertEqual(self.mock_func.call_count, 1)
+
+    def test_retry_on_error_exception_retry_max_attempts(self):
+        self.mock_func.side_effect = CoriolisTestException
+
+        self.assertRaises(CoriolisTestException, utils.retry_on_error(
+            max_attempts=5, sleep_seconds=0,
+            terminal_exceptions=[])(self.mock_func))
+
+        self.assertEqual(self.mock_func.call_count, 5)
+
+    def test_get_udev_net_rules(self):
+        net_ifaces_info = [("eth0", "AA:BB:CC:DD:EE:FF"),
+                           ("eth1", "FF:EE:DD:CC:BB:AA")]
+        expected_result = (
+            'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", '
+            'ATTR{address}=="aa:bb:cc:dd:ee:ff", '
+            'NAME="eth0"\n'
+            'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", '
+            'ATTR{address}=="ff:ee:dd:cc:bb:aa", '
+            'NAME="eth1"\n'
+        )
+
+        result = utils.get_udev_net_rules(net_ifaces_info)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_parse_os_release(self, mock_ssh_cmd):
+        mock_ssh_cmd.return_value = b'ID=ubuntu\nVERSION_ID="20.04"\n'
+
+        result = utils.parse_os_release(self.mock_ssh)
+
+        mock_ssh_cmd.assert_called_once_with(
+            self.mock_ssh,
+            "[ -f '/etc/os-release' ] && cat /etc/os-release || true")
+
+        self.assertEqual(result, ('ubuntu', '20.04'))
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_parse_os_release_no_equal(self, mock_ssh_cmd):
+        mock_ssh_cmd.return_value = b'ID=ubuntu\nVERSION_ID="20.04"\nNOEQUAL\n'
+
+        result = utils.parse_os_release(self.mock_ssh)
+
+        mock_ssh_cmd.assert_called_once_with(
+            self.mock_ssh,
+            "[ -f '/etc/os-release' ] && cat /etc/os-release || true")
+
+        self.assertEqual(result, ("ubuntu", "20.04"))
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_parse_os_release_missing_fields(self, mock_ssh_cmd):
+        mock_ssh_cmd.return_value = b'NO_ID\nNO_VERSION_ID\n'
+
+        result = utils.parse_os_release(self.mock_ssh)
+
+        mock_ssh_cmd.assert_called_once_with(
+            self.mock_ssh,
+            "[ -f '/etc/os-release' ] && cat /etc/os-release || true")
+
+        self.assertIsNone(result)
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_parse_lsb_release(self, mock_ssh_cmd):
+        mock_ssh_cmd.return_value = b'Distributor ID: Ubuntu\nRelease: 20.04\n'
+
+        result = utils.parse_lsb_release(self.mock_ssh)
+
+        mock_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, "lsb_release -a || true")
+
+        self.assertEqual(result, ("Ubuntu", "20.04"))
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_parse_lsb_release_missing_fields(self, mock_ssh_cmd):
+        mock_ssh_cmd.return_value = b'No Distributor ID\nNo Release\n'
+
+        result = utils.parse_lsb_release(self.mock_ssh)
+
+        mock_ssh_cmd.assert_called_once_with(
+            self.mock_ssh,
+            "lsb_release -a || true")
+
+        self.assertIsNone(result)
+
+    @mock.patch.object(utils, 'parse_os_release')
+    def test_get_linux_os_info(self, mock_parse_os_release):
+        result = utils.get_linux_os_info(self.mock_ssh)
+
+        mock_parse_os_release.assert_called_once_with(self.mock_ssh)
+        self.assertEqual(result, mock_parse_os_release.return_value)
+
+    @mock.patch.object(utils, 'parse_os_release')
+    @mock.patch.object(utils, 'parse_lsb_release')
+    def test_get_linux_os_info_lsb_release(self, mock_parse_lsb_release,
+                                           mock_parse_os_release):
+        mock_parse_os_release.return_value = None
+        mock_parse_lsb_release.return_value = ("ubuntu", "20.04")
+
+        result = utils.get_linux_os_info(self.mock_ssh)
+
+        mock_parse_os_release.assert_called_once_with(self.mock_ssh)
+        mock_parse_lsb_release.assert_called_once_with(self.mock_ssh)
+
+        self.assertEqual(result, ("ubuntu", "20.04"))
+
+    def test_test_ssh_path_exists(self):
+        self.mock_sftp.stat.return_value = None
+        self.mock_ssh.open_sftp.return_value = self.mock_sftp
+
+        result = utils.test_ssh_path(self.mock_ssh, "/test/file")
+
+        self.mock_ssh.open_sftp.assert_called_once_with()
+        self.mock_sftp.stat.assert_called_once_with("/test/file")
+
+        self.assertEqual(result, True)
+
+    def test_test_ssh_path_not_exists(self):
+        self.mock_sftp.stat.side_effect = IOError(2,
+                                                  "No such file or directory")
+        self.mock_ssh.open_sftp.return_value = self.mock_sftp
+
+        result = utils.test_ssh_path(self.mock_ssh, "/nonexistent/path")
+
+        self.mock_ssh.open_sftp.assert_called_once_with()
+        self.mock_sftp.stat.assert_called_once_with("/nonexistent/path")
+
+        self.assertEqual(result, False)
+
+    def test_test_ssh_path_raises(self):
+        self.mock_sftp.stat.side_effect = IOError(1, "Some other error")
+        self.mock_ssh.open_sftp.return_value = self.mock_sftp
+
+        original_test_ssh_path = testutils.get_wrapped_function(
+            utils.test_ssh_path)
+
+        self.assertRaises(IOError, original_test_ssh_path, self.mock_ssh,
+                          "/nonexistent/path")
+
+    def test_read_ssh_file(self):
+        self.mock_sftp.open.return_value = self.mock_file
+        self.mock_ssh.open_sftp.return_value = self.mock_sftp
+
+        result = utils.read_ssh_file(self.mock_ssh, "/test/file")
+
+        self.mock_ssh.open_sftp.assert_called_once_with()
+        self.mock_sftp.open.assert_called_once_with("/test/file", "rb")
+
+        self.assertEqual(result, self.mock_file.read.return_value)
+
+    def test_write_ssh_file(self):
+        self.mock_sftp.open.return_value = self.mock_file
+        self.mock_ssh.open_sftp.return_value = self.mock_sftp
+
+        utils.write_ssh_file(self.mock_ssh, "/test/file", b"file content")
+
+        self.mock_ssh.open_sftp.assert_called_once_with()
+        self.mock_sftp.open.assert_called_once_with("/test/file", "wb")
+        self.mock_file.write.assert_called_once_with(b"file content")
+
+    @mock.patch('base64.b64encode')
+    def test_write_winrm_file(self, mock_b64encode):
+        self.mock_conn.test_path.return_value = True
+        self.mock_conn.exec_ps_command.return_value = None
+
+        utils.write_winrm_file(self.mock_conn, "/test/file", "file content",
+                               overwrite=True)
+
+        self.mock_conn.test_path.assert_called_once_with("/test/file")
+        self.assertEqual(self.mock_conn.exec_ps_command.call_count, 2)
+        mock_b64encode.assert_called_once_with(b"file content")
+
+    @mock.patch('base64.b64encode')
+    def test_write_winrm_file_file_does_not_exist(self, mock_b64encode):
+        self.mock_conn.test_path.return_value = False
+        self.mock_conn.exec_ps_command.return_value = None
+
+        utils.write_winrm_file(self.mock_conn, "/nonexistent/path",
+                               "nonexistent-file", overwrite=True)
+
+        self.mock_conn.test_path.assert_called_once_with("/nonexistent/path")
+        mock_b64encode.assert_called_once_with(b"nonexistent-file")
+
+    def test_write_winrm_file_file_exists_overwrite_false(self):
+        self.mock_conn.test_path.return_value = True
+        self.mock_conn.exec_ps_command.return_value = None
+
+        self.assertRaises(exception.CoriolisException, utils.write_winrm_file,
+                          self.mock_conn, "/test/file", "file content",
+                          overwrite=False)
+
+        self.mock_conn.test_path.assert_called_once_with("/test/file")
+
+    @mock.patch('base64.b64encode')
+    def test_write_winrm_file_content_is_not_string(self, mock_b64encode):
+        self.mock_conn.test_path.return_value = False
+        self.mock_conn.exec_ps_command.return_value = None
+
+        utils.write_winrm_file(self.mock_conn, "/test/file", "file content",
+                               overwrite=True)
+
+        self.mock_conn.test_path.assert_called_once_with("/test/file")
+        mock_b64encode.assert_called_once_with(b"file content")
+
+    @mock.patch('base64.b64encode')
+    def test_write_winrm_file_long_content(self, mock_b64encode):
+        self.mock_conn.test_path.return_value = False
+        self.mock_conn.exec_ps_command.return_value = None
+        mock_b64encode.return_value = b'encoded_content'
+        long_content = "a" * 3000
+
+        utils.write_winrm_file(self.mock_conn, "/test/file", long_content,
+                               overwrite=True)
+
+        self.mock_conn.test_path.assert_called_once_with("/test/file")
+        self.assertEqual(self.mock_conn.exec_ps_command.call_count, 2)
+        expected_calls = [mock.call(long_content[:2048].encode()),
+                          mock.call(long_content[2048:].encode())]
+        mock_b64encode.assert_has_calls(expected_calls)
+
+    def test_list_ssh_dir(self):
+        self.mock_ssh.open_sftp.return_value = self.mock_sftp
+
+        result = utils.list_ssh_dir(self.mock_ssh, "/test/file")
+        self.assertEqual(result, self.mock_sftp.listdir.return_value)
+
+        self.mock_ssh.open_sftp.assert_called_once_with()
+        self.mock_sftp.listdir.assert_called_once_with("/test/file")
+
+    def test_exec_ssh_cmd(self):
+        self.mock_stdout.read.return_value = b'output\r\n'
+        self.mock_stdout.channel.recv_exit_status.return_value = 0
+        self.mock_ssh.exec_command.return_value = (
+            None, self.mock_stdout, self.mock_stdout)
+
+        result = utils.exec_ssh_cmd(self.mock_ssh, "command")
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "command", environment=None, get_pty=False, timeout=None)
+
+        self.assertEqual(result, b'output\n')
+
+    def test_exec_ssh_cmd_timeout_with_timeout(self):
+        self.mock_stdout.read.return_value = b'output\n'
+        self.mock_stdout.channel.recv_exit_status.return_value = 0
+        self.mock_ssh.exec_command.return_value = (None, self.mock_stdout,
+                                                   self.mock_stdout)
+
+        result = utils.exec_ssh_cmd(self.mock_ssh, "command", timeout=10)
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "command", environment=None, get_pty=False, timeout=10.0)
+
+        self.assertEqual(result, self.mock_stdout.read.return_value)
+
+    def test_exec_ssh_cmd_getpeername_value_error(self):
+        self.mock_stdout.read.return_value = b'output\n'
+        self.mock_stdout.channel.recv_exit_status.return_value = 0
+        self.mock_ssh.exec_command.return_value = (None, self.mock_stdout,
+                                                   self.mock_stdout)
+
+        self.mock_ssh.get_transport.return_value.sock.\
+            getpeername.side_effect = ValueError
+
+        with self.assertLogs('coriolis.utils', level=logging.WARN):
+            output = utils.exec_ssh_cmd(self.mock_ssh, "command")
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "command", environment=None, get_pty=False, timeout=None)
+
+        self.assertEqual(output, self.mock_stdout.read.return_value)
+
+    def test_exec_ssh_cmd_timeout(self):
+        self.mock_stdout.read.side_effect = socket.timeout
+        self.mock_ssh.exec_command.return_value = (None, self.mock_stdout,
+                                                   self.mock_stdout)
+
+        self.assertRaises(exception.MinionMachineCommandTimeout,
+                          utils.exec_ssh_cmd, self.mock_ssh, "command")
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "command", environment=None, get_pty=False, timeout=None)
+
+    def test_exec_ssh_cmd_exception(self):
+        self.mock_stdout.channel.recv_exit_status.return_value = 1
+        self.mock_ssh.exec_command.return_value = (None, self.mock_stdout,
+                                                   self.mock_stdout)
+
+        original_exec_ssh_cmd = testutils.get_wrapped_function(
+            utils.exec_ssh_cmd)
+
+        self.assertRaises(exception.CoriolisException, original_exec_ssh_cmd,
+                          self.mock_ssh, "command")
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "command", environment=None, get_pty=False, timeout=None)
+
+    def test_exec_ssh_cmd_chroot(self):
+        self.mock_stdout.read.return_value = b'output\n'
+        self.mock_stdout.channel.recv_exit_status.return_value = 0
+        self.mock_ssh.exec_command.return_value = (None, self.mock_stdout,
+                                                   self.mock_stdout)
+
+        result = utils.exec_ssh_cmd_chroot(
+            self.mock_ssh, "/chroot /bin/bash -c", "command")
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "sudo -E chroot /chroot /bin/bash -c command",
+            environment=None, get_pty=False, timeout=None)
+
+        self.assertEqual(result, self.mock_stdout.read.return_value)
+
+    def test_check_fs(self):
+        self.mock_stdout.read.return_value.replace.return_value = \
+            self.mock_stdout.read.return_value
+        self.mock_stdout.channel.recv_exit_status.return_value = 0
+        self.mock_ssh.exec_command.return_value = (None, self.mock_stdout,
+                                                   self.mock_stdout)
+
+        utils.check_fs(self.mock_ssh, "ext4", "/dev/sda1")
+
+        self.mock_ssh.exec_command.assert_called_once_with(
+            "sudo fsck -p -t ext4 /dev/sda1", environment=None, get_pty=True,
+            timeout=None)
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_check_fs_exception(self, mock_exec_ssh_cmd):
+        mock_exec_ssh_cmd.side_effect = exception.CoriolisException()
+
+        self.assertRaises(exception.CoriolisException, utils.check_fs,
+                          self.mock_ssh, "ext4", "/dev/sda1")
+
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, "sudo fsck -p -t ext4 /dev/sda1", get_pty=True)
+
+    @mock.patch.object(utils, 'exec_ssh_cmd')
+    def test_run_xfs_repair(self, mock_exec_ssh_cmd):
+        mock_exec_ssh_cmd.return_value = b"/tmp/tmp_dir\n"
+
+        utils.run_xfs_repair(self.mock_ssh, "/dev/sda1")
+
+        expected_calls = [
+            mock.call(self.mock_ssh, "mktemp -d"),
+            mock.call(self.mock_ssh, "sudo mount /dev/sda1 /tmp/tmp_dir",
+                      get_pty=True),
+            mock.call(self.mock_ssh, "sudo umount /tmp/tmp_dir",
+                      get_pty=True),
+            mock.call(self.mock_ssh, "sudo xfs_repair /dev/sda1",
+                      get_pty=True),
+        ]
+        mock_exec_ssh_cmd.assert_has_calls(expected_calls)
+
+    def test_run_xfs_repair_exception(self):
+        self.mock_ssh.exec_command.side_effect = Exception()
+
+        with self.assertLogs('coriolis.utils', level=logging.WARN):
+            utils.run_xfs_repair(self.mock_ssh, "/dev/sda1")
+
+    @mock.patch('socket.socket')
+    def test_check_port_open_success(self, mock_socket):
+        mock_socket.return_value.connect.return_value = None
+
+        result = utils._check_port_open('localhost', 8080)
+        self.assertEqual(result, True)
+        mock_socket.return_value.close.assert_called_once()
+
+    @mock.patch('socket.socket')
+    def test_check_port_open_exception(self, mock_socket):
+        mock_socket.return_value.connect.side_effect = socket.error
+
+        result = utils._check_port_open('localhost', 8080)
+        self.assertEqual(result, False)
+        mock_socket.return_value.close.assert_called_once()
+
+    @mock.patch.object(utils, '_check_port_open')
+    @mock.patch('time.sleep')
+    def test_wait_for_port_connectivity(self, mock_sleep,
+                                        mock_check_port_open):
+        mock_check_port_open.return_value = True
+        mock_sleep.return_value = None
+
+        utils.wait_for_port_connectivity('localhost', 8080)
+        mock_check_port_open.assert_called_with('localhost', 8080)
+
+    @mock.patch.object(utils, '_check_port_open')
+    @mock.patch('time.sleep')
+    def test_wait_for_port_connectivity_exception(self, mock_sleep,
+                                                  mock_check_port_open):
+        mock_check_port_open.return_value = False
+        mock_sleep.return_value = None
+
+        self.assertRaises(exception.CoriolisException,
+                          utils.wait_for_port_connectivity, 'localhost', 8080,
+                          max_wait=1)
+        mock_check_port_open.assert_called_with('localhost', 8080)
+
+    @mock.patch('subprocess.Popen')
+    def test_exec_process(self, mock_popen):
+        self.mock_process.returncode = 0
+        self.mock_process.communicate.return_value = (b'stdout', b'stderr')
+        mock_popen.return_value = self.mock_process
+
+        result = utils.exec_process("command")
+
+        mock_popen.assert_called_once_with("command", stdout=-1, stderr=-1)
+        self.assertEqual(result, self.mock_process.communicate.return_value[0])
+
+    @mock.patch('subprocess.Popen')
+    def test_exec_process_exception(self, mock_popen):
+        self.mock_process.returncode = 1
+        self.mock_process.communicate.return_value = (b'stdout', b'stderr')
+        mock_popen.return_value = self.mock_process
+
+        self.assertRaises(exception.CoriolisException, utils.exec_process,
+                          "command")
+
+        mock_popen.assert_called_once_with("command", stdout=-1, stderr=-1)
+
+    @mock.patch.object(utils, 'exec_process')
+    def test_get_disk_info(self, mock_exec_process):
+        mock_exec_process.return_value = b'{"format": "vpc"}'
+
+        result = utils.get_disk_info('disk_path')
+
+        self.assertEqual(result, {'format': 'vhd'})
+
+        mock_exec_process.assert_called_with([utils.CONF.qemu_img_path,
+                                              'info', '--output=json',
+                                              'disk_path'])
+
+    @mock.patch.object(utils, 'exec_process')
+    def test_convert_disk_format(self, mock_exec_process):
+        mock_exec_process.return_value = None
+
+        utils.convert_disk_format('disk_path', 'target_disk_path',
+                                  constants.DISK_FORMAT_VHD,
+                                  preallocated=True)
+
+        mock_exec_process.assert_called_with([utils.CONF.qemu_img_path,
+                                              'convert', '-O', 'vpc', '-o',
+                                              'subformat=fixed',
+                                              'disk_path',
+                                              'target_disk_path'])
+
+    def test_convert_disk_format_not_vhd(self):
+        self.assertRaises(NotImplementedError, utils.convert_disk_format,
+                          'disk_path', 'target_disk_path', 'not_vhd',
+                          preallocated=True)
+
+    @mock.patch.object(utils, 'exec_process')
+    @mock.patch.object(utils, 'ignore_exceptions')
+    def test_convert_disk_format_exception(self, mock_ignore_exceptions,
+                                           mock_exec_process):
+        mock_remove = mock.MagicMock()
+        mock_exec_process.side_effect = exception.CoriolisException
+        mock_ignore_exceptions.return_value = mock_remove
+
+        self.assertRaises(exception.CoriolisException,
+                          utils.convert_disk_format, 'disk_path',
+                          'target_disk_path', constants.DISK_FORMAT_VHD,
+                          preallocated=True)
+
+        mock_exec_process.assert_called_with(
+            [utils.CONF.qemu_img_path, 'convert', '-O', 'vpc', '-o',
+             'subformat=fixed', 'disk_path', 'target_disk_path'])
+
+        mock_ignore_exceptions.assert_called_with(os.remove)
+        mock_remove.assert_called_with('target_disk_path')
+
+    def test_walk_class_hierarchy(self):
+        class A:
+            pass
+
+        class B(A):
+            pass
+
+        class C(B):
+            pass
+
+        class D(A):
+            pass
+
+        result = list(utils.walk_class_hierarchy(A))
+        self.assertEqual(result, [C, B, D])
+
+    def test_walk_class_hierarchy_no_subclasses(self):
+        class A:
+            pass
+
+        result = list(utils.walk_class_hierarchy(A, encountered=None))
+        self.assertEqual(result, [])
+
+    @mock.patch('socket.socket')
+    @mock.patch('ssl.SSLContext')
+    @mock.patch('OpenSSL.crypto')
+    def test_get_ssl_cert_thumbprint(self, mock_crypto, mock_ssl_context,
+                                     mock_socket):
+        mock_socket.return_value = mock.MagicMock()
+        mock_ssl_context.return_value = mock.MagicMock()
+
+        result = utils.get_ssl_cert_thumbprint(
+            mock_ssl_context.return_value, 'localhost',
+            digest_algorithm='sha1')
+
+        self.assertEqual(result, mock_crypto.load_certificate.return_value.
+                         digest.return_value.decode.return_value)
+        mock_crypto.load_certificate.return_value.digest.\
+            assert_called_once_with('sha1')
+
+    @mock.patch('os.path')
+    def test_get_resources_dir(self, mock_path):
+        mock_path.dirname.return_value = 'dirname'
+        mock_path.abspath.return_value = 'dirname/abs_path'
+
+        result = utils.get_resources_dir()
+
+        self.assertEqual(result, mock_path.join.return_value)
+
+    @mock.patch('os.path')
+    def test_get_resources_bin_dir(self, mock_path):
+        mock_path.dirname.return_value = 'dirname'
+        mock_path.abspath.return_value = 'dirname/abs_path '
+
+        result = utils.get_resources_bin_dir()
+
+        self.assertEqual(result, mock_path.join.return_value)
+
+    def test_serialize_key(self):
+        mock_key = mock.MagicMock()
+        mock_key.write_private_key.return_value = None
+
+        utils.serialize_key(mock_key, password='password')
+
+        args, _ = mock_key.write_private_key.call_args
+
+        self.assertEqual(args[1], 'password')
+
+    @mock.patch('io.StringIO')
+    @mock.patch('paramiko.RSAKey')
+    def test_deserialize_key(self, mock_rsa_key, mock_string_io):
+        mock_string_io.return_value = mock.MagicMock()
+
+        result = utils.deserialize_key('key', password='password')
+
+        mock_rsa_key.from_private_key.assert_called_with(
+            mock_string_io.return_value, 'password')
+        self.assertEqual(result, mock_rsa_key.from_private_key.return_value)
+
+    @mock.patch('coriolis.utils.jsonutils.dumps')
+    @mock.patch('coriolis.utils.jsonutils.loads')
+    def test_to_dict(self, mock_loads, mock_dumps):
+        mock_dumps.return_value = 'json'
+        obj = mock.MagicMock()
+
+        result = utils.to_dict(obj)
+
+        mock_dumps.assert_called_once_with(obj, default=mock.ANY)
+        mock_loads.assert_called_once_with(mock_dumps.return_value)
+
+        self.assertEqual(result, mock_loads.return_value)
+
+    def test_to_dict_with_primitive(self):
+        obj = datetime.datetime.now()
+        result = utils.to_dict(obj)
+
+        self.assertEqual(result, obj.isoformat())
+
+    def test_load_class(self):
+        class_path = 'json.JSONDecoder'
+        result = utils.load_class(class_path)
+
+        self.assertEqual(result, json.JSONDecoder)
+
+    def test_check_md5_with_matching_hashes(self):
+        data = b'test data'
+        md5 = hashlib.md5(data).hexdigest()
+        utils.check_md5(data, md5)
+
+    def test_check_md5_with_exception(self):
+        data = b'test data'
+        md5 = hashlib.md5(b'other data').hexdigest()
+        self.assertRaises(exception.CoriolisException, utils.check_md5, data,
+                          md5)
+
+    @mock.patch.object(utils, 'secrets')
+    def test_get_secret_connection_info_with_secret_ref(self, mock_secrets):
+        with self.assertLogs('coriolis.utils', level=logging.INFO):
+            result = utils.get_secret_connection_info('context',
+                                                      {'secret_ref': 'ref'})
+
+        self.assertEqual(result, mock_secrets.get_secret.return_value)
+
+    def test_get_secret_connection_info_with_no_secret_ref(self):
+        result = utils.get_secret_connection_info('context', {})
+        self.assertEqual(result, {})
+
+    @ddt.data(123, '123')
+    def test_parse_int_value_with_valid_input(self, value):
+        result = utils.parse_int_value(value)
+        self.assertEqual(result, 123)
+
+    @ddt.data('invalid', '123.45', None)
+    def test_parse_int_value_with_invalid_input(self, value):
+        self.assertRaises(exception.InvalidInput, utils.parse_int_value, value)
+
+    @ddt.data(
+        ('SGVsbG8gd29ybGQ=', False, 'Hello world'),
+        ('eyJ0ZXN0IjogInZhbHVlIn0=', True, {'test': 'value'}),
+    )
+    @ddt.unpack
+    def test_decode_base64_param(self, value, is_json, expected):
+        result = utils.decode_base64_param(value, is_json=is_json)
+        self.assertEqual(result, expected)
+
+    @ddt.data(
+        ('invalid', False),
+        ('invalid', True),
+        ('SGVsbG8gd29ybGQ=', True),
+    )
+    @ddt.unpack
+    def test_decode_base64_param_with_invalid_input(self, value, is_json):
+        self.assertRaises(exception.InvalidInput, utils.decode_base64_param,
+                          value, is_json=is_json)
+
+    def test_quote_url(self):
+        result = utils.quote_url('Hello world')
+        self.assertEqual(result, 'Hello%20world')
+
+    @ddt.data(
+        ('00-11-22-33-44-55', '00:11:22:33:44:55'),
+        ('00:11:22:33:44:55', '00:11:22:33:44:55'),
+        ('001122334455', '00:11:22:33:44:55'),
+        ('00-11-22-AA-BB-CC', '00:11:22:aa:bb:cc'),
+    )
+    @ddt.unpack
+    def test_normalize_mac_address(self, input, expected):
+        result = utils.normalize_mac_address(input)
+        self.assertEqual(result, expected)
+
+    @ddt.data(
+        'invalid',
+        '00112233445566',
+        '00-11-22-33-44-GG',
+        123456789012,
+    )
+    def test_normalize_mac_address_with_invalid_input(self, input):
+        self.assertRaises(ValueError, utils.normalize_mac_address,
+                          input)
+
+    def test_get_url_with_credentials(self):
+        url = 'http://example.com'
+        username = 'user'
+        password = 'pass'
+        expected = 'http://user:pass@example.com'
+
+        result = utils.get_url_with_credentials(url, username, password)
+
+        self.assertEqual(result, expected)
+
+    def test_get_url_with_credentials_existing_credentials(self):
+        url = 'http://olduser:oldpass@example.com'
+        username = 'newuser'
+        password = 'newpass'
+        expected = 'http://newuser:newpass@example.com'
+
+        result = utils.get_url_with_credentials(url, username, password)
+
+        self.assertEqual(result, expected)
+
+    @ddt.data(
+        (
+            [
+                {'id': '1', 'name': 'Resource1'},
+                {'id': '2', 'name': 'Resource2'},
+                {'id': '3', 'name': 'Resource1'}
+            ],
+            ['Resource2', '1', '3']
+        ),
+        (
+            [
+                {'id': '1', 'name': 'Resource1'},
+                {'id': '2', 'name': 'Resource2'},
+                {'id': '3', 'name': 'Resource3'}
+            ],
+            ['Resource1', 'Resource2', 'Resource3']
+        ),
+        (
+            [
+                {'id': '1', 'name': 'Resource1'},
+                {'id': '2', 'name': 'Resource2'},
+                {'id': '3'}
+            ],
+            KeyError
+        )
+    )
+    @ddt.unpack
+    def test_get_unique_option_ids(self, resources, expected):
+        if isinstance(expected, list):
+            result = utils.get_unique_option_ids(resources)
+            self.assertEqual(sorted(result), sorted(expected))
+        else:
+            self.assertRaises(expected, utils.get_unique_option_ids, resources)
+
+    def test_get_unique_option_ids_with_custom_keys(self):
+        resources = [
+            {'custom_id': '1', 'custom_name': 'Resource1'},
+            {'custom_id': '2', 'custom_name': 'Resource2'},
+            {'custom_id': '3', 'custom_name': 'Resource1'}
+        ]
+        expected_result = ['Resource2', '1', '3']
+        result = utils.get_unique_option_ids(
+            resources, id_key='custom_id', name_key='custom_name')
+        self.assertEqual(sorted(result), sorted(expected_result))
+
+    def test_bad_request_on_error(self):
+        @utils.bad_request_on_error("An error occurred: %s")
+        def mock_func():
+            return (True, "Everything is fine")
+
+        is_valid, message = mock_func()
+        self.assertTrue(is_valid)
+        self.assertEqual(message, "Everything is fine")
+
+    def test_bad_request_on_error_httpBadRequest(self):
+        @utils.bad_request_on_error("An error occurred: %s")
+        def mock_func():
+            return (False, "Something is wrong")
+
+        self.assertRaises(exc.HTTPBadRequest, mock_func)
+
+    @ddt.data(
+        ({
+            "key1": "value1",
+            "origin": {"connection_info": "sensitive_info"},
+            "destination": {"connection_info": "sensitive_info"},
+            "volumes_info": [
+                {
+                    "key2": "value2",
+                    "replica_state": {
+                        "key3": "value3",
+                        "chunks": "sensitive_info"
+                    }
+                }
+            ]
+        }, {
+            "key1": "value1",
+            "origin": {"connection_info": {"got": "redacted"}},
+            "destination": {"connection_info": {"got": "redacted"}},
+            "volumes_info": [
+                {
+                    "key2": "value2",
+                    "replica_state": {
+                        "key3": "value3",
+                        "chunks": ["<redacted>"]
+                    }
+                }
+            ]
+        }),
+        ({
+            "key1": "value1",
+            "key2": "value2",
+        }, {
+            "key1": "value1",
+            "key2": "value2",
+        }),
+    )
+    @ddt.unpack
+    def test_sanitize_task_info(self, task_info, expected):
+        result = utils.sanitize_task_info(task_info)
+        self.assertEqual(result, expected)
+        self.assertIsInstance(result, dict)
+
+    def test_parse_ini_config(self):
+        file_contents = 'key1 = value1\nkey2 = value2\nkey3 = value3'
+        expected = {
+            "key1": "value1",
+            "key2": "value2",
+            "key3": "value3",
+        }
+
+        result = utils.parse_ini_config(file_contents)
+        self.assertEqual(result, expected)
+        self.assertIsInstance(result, dict)
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    @mock.patch('coriolis.utils.read_ssh_file')
+    @mock.patch('coriolis.utils.parse_ini_config')
+    def test_read_ssh_ini_config_file_check_false(self, mock_parse_ini_config,
+                                                  mock_read_ssh_file,
+                                                  mock_test_ssh_path):
+        mock_test_ssh_path.return_value = True
+
+        result = utils.read_ssh_ini_config_file(self.mock_ssh, '/test/file',
+                                                check_exists=False)
+
+        self.assertEqual(result, mock_parse_ini_config.return_value)
+        mock_read_ssh_file.assert_called_once_with(self.mock_ssh, '/test/file')
+        mock_parse_ini_config.assert_called_once_with(
+            mock_read_ssh_file.return_value.decode())
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_read_ssh_ini_config_file_check_true_path_not_exists(
+            self, mock_test_ssh_path):
+        mock_test_ssh_path.return_value = False
+
+        result = utils.read_ssh_ini_config_file(self.mock_ssh, '/test/to/file',
+                                                check_exists=True)
+
+        self.assertEqual(result, {})
+        mock_test_ssh_path.assert_called_once_with(self.mock_ssh,
+                                                   '/test/to/file')
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.write_ssh_file')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    @mock.patch.object(uuid, 'uuid4')
+    def test_write_systemd(self, mock_uuid, mock_test_ssh,
+                           mock_write_ssh_file, mock_exec_ssh_cmd):
+        mock_uuid.return_value = 'uuid'
+        mock_test_ssh.return_value = False
+        mock_write_ssh_file.return_value = None
+
+        utils._write_systemd(self.mock_ssh, 'cmdline', 'svc_name')
+
+        mock_uuid.assert_called_once_with()
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/lib/systemd/system/svc_name.service')
+        mock_write_ssh_file.assert_called_once_with(self.mock_ssh,
+                                                    '/tmp/uuid.service',
+                                                    mock.ANY)
+        mock_exec_ssh_cmd.assert_has_calls([
+            mock.call(self.mock_ssh, 'sudo mv /tmp/uuid.service '
+                      '/lib/systemd/system/svc_name.service', get_pty=True),
+            mock.call(self.mock_ssh, 'sudo restorecon -v '
+                      '/lib/systemd/system/svc_name.service', get_pty=True),
+            mock.call(self.mock_ssh, 'sudo systemctl daemon-reload',
+                      get_pty=True),
+            mock.call(self.mock_ssh, 'sudo systemctl start svc_name',
+                      get_pty=True)])
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_write_systemd_service_exists(self, mock_test_ssh):
+        mock_test_ssh.return_value = True
+
+        utils._write_systemd(self.mock_ssh, 'cmdline', 'svc_name')
+
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/lib/systemd/system/svc_name.service')
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.write_ssh_file')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    @mock.patch.object(uuid, 'uuid4')
+    def test_write_systemd_service_selinux_exception(self, mock_uuid,
+                                                     mock_test_ssh,
+                                                     mock_write_ssh_file,
+                                                     mock_exec_ssh_cmd):
+        mock_uuid.return_value = 'uuid'
+        mock_test_ssh.return_value = False
+        mock_write_ssh_file.return_value = None
+        mock_exec_ssh_cmd.side_effect = [
+            None, exception.CoriolisException(), None, None]
+
+        _write_systemd_undecorated = testutils.get_wrapped_function(
+            utils._write_systemd)
+
+        with self.assertLogs('coriolis.utils', level=logging.WARN):
+            _write_systemd_undecorated(self.mock_ssh, '/test/file', 'svc_name',
+                                       start=True)
+
+        mock_uuid.assert_called_once_with()
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/lib/systemd/system/svc_name.service')
+        mock_write_ssh_file.assert_called_once_with(self.mock_ssh,
+                                                    '/tmp/uuid.service',
+                                                    mock.ANY)
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.write_ssh_file')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    @mock.patch.object(uuid, 'uuid4')
+    def test_test_write_systemd_with_run_as(self, mock_uuid, mock_test_ssh,
+                                            mock_write_ssh_file,
+                                            mock_exec_ssh_cmd):
+
+        mock_uuid.return_value = 'uuid'
+        mock_test_ssh.return_value = False
+
+        utils._write_systemd(self.mock_ssh, 'cmdline', 'svc_name',
+                             run_as='test_user')
+
+        mock_uuid.assert_called_once_with()
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/lib/systemd/system/svc_name.service')
+        mock_write_ssh_file.assert_called_once_with(
+            self.mock_ssh, '/tmp/uuid.service',
+            utils.SYSTEMD_TEMPLATE % {
+                "cmdline": 'cmdline',
+                "username": 'test_user',
+                "svc_name": 'svc_name'})
+
+        mock_exec_ssh_cmd.assert_has_calls([
+            mock.call(self.mock_ssh, 'sudo mv /tmp/uuid.service '
+                      '/lib/systemd/system/svc_name.service', get_pty=True),
+            mock.call(self.mock_ssh, 'sudo restorecon -v '
+                      '/lib/systemd/system/svc_name.service', get_pty=True),
+            mock.call(self.mock_ssh, 'sudo systemctl daemon-reload',
+                      get_pty=True),
+            mock.call(self.mock_ssh, 'sudo systemctl start svc_name',
+                      get_pty=True)])
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.write_ssh_file')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    @mock.patch.object(uuid, 'uuid4')
+    def test_write_upstart(self, mock_uuid, mock_test_ssh,
+                           mock_write_ssh_file, mock_exec_ssh_cmd):
+        mock_uuid.return_value = 'uuid'
+        mock_test_ssh.return_value = False
+        mock_write_ssh_file.return_value = None
+
+        utils._write_upstart(self.mock_ssh, 'cmdline', 'svc_name')
+
+        mock_uuid.assert_called_once_with()
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/etc/init/svc_name.conf')
+        mock_write_ssh_file.assert_called_once_with(self.mock_ssh,
+                                                    '/tmp/uuid.conf',
+                                                    mock.ANY)
+        mock_exec_ssh_cmd.assert_has_calls([
+            mock.call(self.mock_ssh, 'sudo mv /tmp/uuid.conf '
+                      '/etc/init/svc_name.conf', get_pty=True),
+            mock.call(self.mock_ssh, 'start svc_name')])
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_write_upstart_service_exists(self, mock_test_ssh):
+        mock_test_ssh.return_value = True
+
+        utils._write_upstart(self.mock_ssh, 'cmdline', 'svc_name')
+
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/etc/init/svc_name.conf')
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.write_ssh_file')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    @mock.patch.object(uuid, 'uuid4')
+    def test_write_upstart_with_run_as(self, mock_uuid, mock_test_ssh,
+                                       mock_write_ssh_file,
+                                       mock_exec_ssh_cmd):
+        mock_uuid.return_value = 'uuid'
+        mock_test_ssh.return_value = False
+
+        utils._write_upstart(self.mock_ssh, 'cmdline', 'svc_name',
+                             run_as='test-user')
+
+        mock_uuid.assert_called_once_with()
+        mock_test_ssh.assert_called_once_with(
+            self.mock_ssh, '/etc/init/svc_name.conf')
+        mock_write_ssh_file.assert_called_once_with(
+            self.mock_ssh, '/tmp/uuid.conf',
+            utils.UPSTART_TEMPLATE % {
+                "cmdline": 'sudo -u test-user -- cmdline',
+                "svc_name": 'svc_name'})
+
+        mock_exec_ssh_cmd.assert_has_calls([
+            mock.call(self.mock_ssh, 'sudo mv /tmp/uuid.conf '
+                      '/etc/init/svc_name.conf', get_pty=True),
+            mock.call(self.mock_ssh, 'start svc_name')])
+
+    @mock.patch('coriolis.utils._write_systemd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_create_service_systemd(self, mock_test_ssh, mock_write_systemd):
+        mock_test_ssh.return_value = True
+
+        utils.create_service(self.mock_ssh, 'cmdline', 'svc_name',
+                             run_as='user', start=True)
+
+        mock_write_systemd.assert_called_once_with(self.mock_ssh, 'cmdline',
+                                                   'svc_name', run_as='user',
+                                                   start=True)
+
+    @mock.patch('coriolis.utils._write_upstart')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_create_service_upstart(self, mock_test_ssh, mock_write_upstart):
+        mock_test_ssh.side_effect = [False, True]
+
+        utils.create_service(self.mock_ssh, 'cmdline', 'svc_name',
+                             run_as='user', start=True)
+
+        mock_write_upstart.assert_called_once_with(self.mock_ssh, 'cmdline',
+                                                   'svc_name', run_as='user',
+                                                   start=True)
+
+    @mock.patch('coriolis.utils._write_systemd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_create_service_exception(self, mock_test_ssh, mock_write_systemd):
+        mock_test_ssh.return_value = False
+
+        create_svc_undecorated = testutils.get_wrapped_function(
+            utils.create_service)
+
+        self.assertRaises(exception.CoriolisException, create_svc_undecorated,
+                          self.mock_ssh, 'cmdline', 'svc_name', run_as='user',
+                          start=True)
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_restart_service_with_systemd(self, mock_test_ssh,
+                                          mock_exec_ssh_cmd):
+        mock_test_ssh.return_value = True
+
+        utils.restart_service(self.mock_ssh, 'svc_name')
+
+        mock_test_ssh.assert_called_once_with(self.mock_ssh,
+                                              '/lib/systemd/system')
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, 'sudo systemctl restart svc_name', get_pty=True)
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_restart_service_with_upstart(self, mock_test_ssh,
+                                          mock_exec_ssh_cmd):
+        mock_test_ssh.side_effect = [False, True]
+
+        utils.restart_service(self.mock_ssh, 'svc_name')
+
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, 'restart svc_name')
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_restart_service_exception(self, mock_test_ssh):
+        mock_test_ssh.return_value = False
+
+        restart_svc_undecorated = testutils.get_wrapped_function(
+            utils.restart_service)
+
+        self.assertRaises(exception.UnrecognizedWorkerInitSystem,
+                          restart_svc_undecorated, self.mock_ssh, 'svc_name')
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_start_service_with_systemd(self, mock_test_ssh,
+                                        mock_exec_ssh_cmd):
+        mock_test_ssh.return_value = True
+
+        utils.start_service(self.mock_ssh, 'svc_name')
+
+        mock_test_ssh.assert_called_once_with(self.mock_ssh,
+                                              '/lib/systemd/system')
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, 'sudo systemctl start svc_name', get_pty=True)
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_start_service_with_upstart(self, mock_test_ssh,
+                                        mock_exec_ssh_cmd):
+        mock_test_ssh.side_effect = [False, True]
+
+        utils.start_service(self.mock_ssh, 'svc_name')
+
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, 'start svc_name')
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_start_service_exception(self, mock_test_ssh):
+        mock_test_ssh.return_value = False
+
+        start_svc_undecorated = testutils.get_wrapped_function(
+            utils.start_service)
+
+        self.assertRaises(exception.UnrecognizedWorkerInitSystem,
+                          start_svc_undecorated, self.mock_ssh, 'svc_name')
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_stop_service_with_systemd(self, mock_test_ssh,
+                                       mock_exec_ssh_cmd):
+        mock_test_ssh.return_value = True
+
+        utils.stop_service(self.mock_ssh, 'svc_name')
+
+        mock_test_ssh.assert_called_once_with(self.mock_ssh,
+                                              '/lib/systemd/system')
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, 'sudo systemctl stop svc_name', get_pty=True)
+
+    @mock.patch('coriolis.utils.exec_ssh_cmd')
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_stop_service_with_upstart(self, mock_test_ssh,
+                                       mock_exec_ssh_cmd):
+        mock_test_ssh.side_effect = [False, True]
+
+        utils.stop_service(self.mock_ssh, 'svc_name')
+
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.mock_ssh, 'stop svc_name')
+
+    @mock.patch('coriolis.utils.test_ssh_path')
+    def test_stop_service_exception(self, mock_test_ssh):
+        mock_test_ssh.return_value = False
+
+        stop_svc_undecorated = testutils.get_wrapped_function(
+            utils.stop_service)
+
+        self.assertRaises(exception.UnrecognizedWorkerInitSystem,
+                          stop_svc_undecorated, self.mock_ssh, 'svc_name')
+
+
+@ddt.ddt
+class Grub2ConfigEditorTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis Grub2ConfigEditor class."""
+
+    def setUp(self):
+        super(Grub2ConfigEditorTestCase, self).setUp()
+        self.cfg = "test configuration"
+        self.parser = utils.Grub2ConfigEditor(self.cfg)
+
+    def test__init__(self):
+        result = utils.Grub2ConfigEditor(self.cfg)
+        self.assertEqual(
+            result._parsed, [{'type': 'raw', 'payload': self.cfg}])
+
+    def test_parse_cfg_comment_line(self):
+        self.cfg = '# This is a comment'
+
+        result = self.parser._parse_cfg(self.cfg)
+        self.assertEqual(result, [{'type': 'raw', 'payload': self.cfg}])
+
+    def test_parse_cfg_option_line_with_quoted_value(self):
+        self.cfg = 'option="value"'
+        expected_result = [{'type': 'option', 'payload': self.cfg,
+                            'quoted': True, 'option_name': 'option',
+                            'option_value':
+                            [{'opt_type': 'single', 'opt_val': 'value'}]}]
+
+        result = self.parser._parse_cfg(self.cfg)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_cfg_option_line_without_value(self):
+        self.cfg = 'option='
+        expected_result = [{'type': 'option', 'payload': self.cfg,
+                            'quoted': False, 'option_name': 'option',
+                            'option_value':
+                            [{'opt_type': 'single', 'opt_val': ''}]}]
+
+        result = self.parser._parse_cfg(self.cfg)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_cfg_option_line_with_value(self):
+        self.cfg = 'option=value'
+        expected_result = [{'type': 'option', 'payload': self.cfg,
+                            'quoted': False, 'option_name': 'option',
+                            'option_value':
+                            [{'opt_type': 'single', 'opt_val': 'value'}]}]
+
+        result = self.parser._parse_cfg(self.cfg)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_cfg_option_line_with_multiple_values(self):
+        self.cfg = 'option=value1 value2'
+        expected_result = [{'type': 'option', 'payload': self.cfg,
+                            'quoted': False, 'option_name': 'option',
+                            'option_value':
+                            [{'opt_type': 'single', 'opt_val': 'value1'},
+                             {'opt_type': 'single', 'opt_val': 'value2'}]}]
+
+        result = self.parser._parse_cfg(self.cfg)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_cfg_option_line_with_key_value(self):
+        self.cfg = 'option=key=value'
+        expected_result = [{'type': 'option', 'payload': self.cfg,
+                            'quoted': False, 'option_name': 'option',
+                            'option_value':
+                            [{'opt_type': 'key_val', 'opt_val': 'value',
+                              'opt_key': 'key'}]}]
+
+        result = self.parser._parse_cfg(self.cfg)
+        self.assertEqual(result, expected_result)
+
+    @ddt.data(
+        ("not a dict", ValueError),
+        ({"opt_type": "invalid"}, ValueError),
+        ({"opt_type": "key_val"}, ValueError),
+        ({"opt_type": "single"}, ValueError),
+        ({"unknown_opt_type"}, ValueError),
+        ({"opt_type": "key_val", "opt_key": "key", "opt_val": "val"}, None),
+        ({"opt_type": "single", "opt_val": "val"}, None),
+    )
+    @ddt.unpack
+    def test_validate_value(self, value, expected):
+        if expected:
+            self.assertRaises(expected, self.parser._validate_value, value)
+        else:
+            self.parser._validate_value(value)
+
+    def test_set_option_updates_existing_option(self):
+        self.parser._parsed = [{"option_name": "existing_option",
+                                "option_value": ["old_value"]}]
+        new_value = {"opt_type": "key_val", "opt_key": "key", "opt_val":
+                     "new_value"}
+        expected_value = [{"option_name": "existing_option",
+                           "option_value": [new_value]}]
+
+        self.parser.set_option("existing_option", new_value)
+        self.assertEqual(self.parser._parsed, expected_value)
+
+    def test_set_option_adds_new_option(self):
+        self.parser._parsed = [{"option_name": "existing_option",
+                                "option_value": ["old_value"]}]
+        new_value = {"opt_type": "key_val", "opt_key": "key",
+                     "opt_val": "new_value", "quoted": True, "type": "option"}
+        expected_value = [{"option_name": "existing_option", "option_value":
+                           ["old_value"]}, {"option_name": "new_option",
+                                            "option_value": [new_value],
+                                            "quoted": True, "type": "option"}]
+
+        self.parser.set_option("new_option", new_value)
+        self.assertEqual(self.parser._parsed, expected_value)
+
+    def test_append_to_option_updates_existing_key_val_option(self):
+        self.parser._parsed = [{"option_name": "existing_option",
+                                "option_value": [{"opt_type": "key_val",
+                                                  "opt_key": "key",
+                                                  "opt_val": "old_value"}]}]
+        new_value = {"opt_type": "key_val", "opt_key": "key",
+                     "opt_val": "new_value"}
+        expected_value = [{"option_name": "existing_option", "option_value":
+                           [new_value]}]
+
+        self.parser.append_to_option("existing_option", new_value)
+        self.assertEqual(self.parser._parsed, expected_value)
+
+    def test_append_to_option_ignores_existing_single_option(self):
+        self.parser._parsed = [{"option_name": "existing_option",
+                                "option_value": [{"opt_type": "single",
+                                                  "opt_val": "old_value"}]}]
+        new_value = {"opt_type": "single", "opt_val": "old_value"}
+        expected_value = [{"option_name": "existing_option",
+                           "option_value": [new_value]}]
+
+        self.parser.append_to_option("existing_option", new_value)
+        self.assertEqual(self.parser._parsed, expected_value)
+
+    def test_append_to_option_adds_new_single_option(self):
+        self.parser._parsed = [{"option_name": "existing_option",
+                                "option_value": [{"opt_type": "single",
+                                                  "opt_val": "old_value"}]}]
+        new_value = {"opt_type": "single", "opt_val": "new_value"}
+        expected_value = [{
+            "option_name": "existing_option", "option_value":
+            [{"opt_type": "single", "opt_val": "old_value"}, new_value]}]
+
+        self.parser.append_to_option("existing_option", new_value)
+        self.assertEqual(self.parser._parsed, expected_value)
+
+    def test_append_to_option_adds_new_option(self):
+        self.parser._parsed = [{"option_name": "existing_option",
+                                "option_value": [{"opt_type": "single",
+                                                  "opt_val": "old_value"}]}]
+        new_value = {"opt_type": "key_val", "opt_key": "key", "opt_val":
+                     "new_value"}
+        expected_value = [{
+            "option_name": "existing_option", "option_value":
+            [{"opt_type": "single", "opt_val": "old_value"}]},
+            {"option_name": "new_option", "option_value": [new_value],
+             "quoted": True, "type": "option"}]
+
+        self.parser.append_to_option("new_option", new_value)
+        self.assertEqual(self.parser._parsed, expected_value)
+
+    @ddt.data(
+        (
+            [{"type": "raw", "payload": "raw_data"}],
+            "raw_data\n"
+        ),
+        (
+            [{"type": "option", "option_name": "option1", "option_value":
+              [{"opt_type": "single", "opt_val": "value1"}], "quoted": False}],
+            "option1=value1\n"
+        ),
+        (
+            [{"type": "option", "option_name": "option2", "option_value":
+              [{"opt_type": "key_val", "opt_key": "key2",
+                "opt_val": "value2"}],
+                "quoted": True}], "option2=\"key2=value2\"\n"
+        ),
+        (
+            [{"type": "option", "option_name": "option3", "option_value": [],
+              "quoted": False}], "option3=\n"
+        ),
+        (
+            [{"type": "option", "option_name": "option4", "option_value":
+              [{"opt_type": "single", "opt_val": "value4_1"},
+               {"opt_type": "single", "opt_val":
+                "value4_2"}], "quoted": False}],
+            "option4=\"value4_1 value4_2\"\n"
+        ))
+    @ddt.unpack
+    def test_dump(self, parsed, expected_output):
+        self.parser._parsed = parsed
+        self.assertEqual(self.parser.dump(), expected_output)

--- a/coriolis/tests/test_wsman.py
+++ b/coriolis/tests/test_wsman.py
@@ -1,0 +1,171 @@
+# Copyright 2023 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+import requests
+from winrm import protocol
+
+from coriolis import exception
+from coriolis.tests import test_base
+from coriolis import wsman
+
+
+class WSManConnectionTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis WSManConnection class."""
+
+    def setUp(self):
+        super(WSManConnectionTestCase, self).setUp()
+        self.conn = wsman.WSManConnection()
+        self.conn._protocol = mock.Mock()
+        self.conn._conn_timeout = 10
+        self.cmd = "test_cmd"
+        self.args = ["arg1", "arg2"]
+        self.url = "http://example.com/file"
+        self.remote_path = "/remote/path"
+
+    def test__init__timeout(self):
+        self.connection = wsman.WSManConnection()
+        self.assertEqual(self.connection._conn_timeout, wsman.DEFAULT_TIMEOUT)
+
+    def test__init__timeout_set(self):
+        self.connection = wsman.WSManConnection(timeout=100)
+        self.assertEqual(self.connection._conn_timeout, 100)
+
+    @mock.patch.object(protocol, 'Protocol')
+    def test_connect(self, mock_protocol):
+        self.conn.connect('url', 'username', cert_pem='test_cert')
+        mock_protocol.assert_called_once_with(
+            endpoint='url',
+            transport='ssl',
+            username='username',
+            password=None,
+            cert_pem="test_cert",
+            cert_key_pem=None
+        )
+
+    @mock.patch.object(protocol, 'Protocol')
+    def test_connect_no_auth(self, mock_protocol):
+        self.conn.connect('url', 'username')
+        mock_protocol.assert_called_once_with(
+            endpoint='url',
+            transport='plaintext',
+            username='username',
+            password=None,
+            cert_pem=None,
+            cert_key_pem=None
+        )
+
+    @mock.patch.object(wsman.WSManConnection, 'connect')
+    @mock.patch('coriolis.utils.wait_for_port_connectivity')
+    def test_from_connection_info(self, mock_wait_for_port_connectivity,
+                                  mock_connect):
+        connection_info = {
+            "ip": "127.0.0.1",
+            "username": "user",
+            "password": "pass",
+        }
+        result = self.conn.from_connection_info(connection_info)
+        mock_wait_for_port_connectivity.assert_called_once_with(
+            "127.0.0.1", 5986)
+        mock_connect.assert_called_once_with(
+            url="https://127.0.0.1:5986/wsman", username="user",
+            password="pass", cert_pem=None, cert_key_pem=None)
+        self.assertIsInstance(result, self.conn.__class__)
+
+    def test_from_connection_info_missing_keys(self):
+        self.assertRaises(ValueError, self.conn.from_connection_info,
+                          {"username": "user", "password": "pass"})
+
+    def test_from_connection_info_invalid_type(self):
+        self.assertRaises(ValueError, self.conn.from_connection_info,
+                          'invalid-connection-type')
+
+    def test_disconnect(self):
+        self.conn.disconnect()
+        self.assertIsNone(self.conn._protocol)
+
+    def test_set_timeout(self):
+        self.conn.set_timeout(self.conn._conn_timeout)
+        self.assertEqual(self.conn._protocol.transport.timeout,
+                         self.conn._conn_timeout)
+        self.assertEqual(self.conn._protocol.timeout,
+                         self.conn._conn_timeout)
+
+    def test__exec_command(self):
+        self.conn._protocol.get_command_output.return_value = (
+            "std_out", "std_err", 0)
+        std_out, std_err, exit_code = self.conn._exec_command(
+            self.cmd, self.args)
+        self.assertEqual(std_out, "std_out")
+        self.assertEqual(std_err, "std_err")
+        self.assertEqual(exit_code, 0)
+
+        self.conn._protocol.open_shell.assert_called_once_with(
+            codepage=wsman.CODEPAGE_UTF8)
+        shell_id = self.conn._protocol.open_shell.return_value
+        self.conn._protocol.run_command.assert_called_once_with(
+            shell_id, self.cmd, self.args)
+        command_id = self.conn._protocol.run_command.return_value
+        self.conn._protocol.get_command_output.assert_called_once_with(
+            shell_id, command_id)
+        self.conn._protocol.cleanup_command.assert_called_once_with(
+            shell_id, command_id)
+        self.conn._protocol.close_shell.assert_called_once_with(shell_id)
+
+    def test__exec_command_exception(self):
+        self.conn._protocol.get_command_output.side_effect = requests.\
+            exceptions.ReadTimeout
+        self.assertRaises(exception.OSMorphingWinRMOperationTimeout,
+                          self.conn._exec_command, self.cmd, self.args)
+        self.conn._protocol.cleanup_command.assert_called_once_with(
+            mock.ANY, mock.ANY)
+        self.conn._protocol.close_shell.assert_called_once_with(mock.ANY)
+
+    def test_exec_command(self):
+        self.conn._protocol.get_command_output.return_value = (
+            "std_out", "std_err", 0)
+        std_out = self.conn.exec_command(self.cmd, self.args)
+        self.assertEqual(std_out, "std_out")
+
+    def test_exec_command_exception(self):
+        self.conn._protocol.get_command_output.return_value = (
+            "std_out", "std_err", 1)
+        self.assertRaises(exception.CoriolisException, self.conn.exec_command,
+                          self.cmd, self.args)
+
+    def test_exec_ps_command(self):
+        self.conn.exec_command = mock.Mock()
+        self.conn.exec_command.return_value = "std_out\n\n"
+        result = self.conn.exec_ps_command(self.cmd)
+        self.conn.exec_command.assert_called_once_with(
+            "powershell.exe", ["-EncodedCommand", 'dABlAHMAdABfAGMAbQBkAA=='],
+            timeout=None)
+        self.assertEqual(result, "std_out")
+
+    def test_test_path(self):
+        self.conn.exec_ps_command = mock.Mock()
+        self.conn.exec_ps_command.return_value = "True"
+        result = self.conn.test_path("test_path")
+        self.conn.exec_ps_command.assert_called_once_with(
+            "Test-Path -Path \"test_path\"")
+        self.assertTrue(result)
+
+    def test_download_file(self):
+        self.conn.exec_ps_command = mock.Mock()
+        self.conn.download_file(self.url, self.remote_path)
+        self.conn.exec_ps_command.assert_called_once()
+
+    def test_download_file_exception(self):
+        self.conn.exec_ps_command = mock.Mock()
+        self.conn.exec_ps_command.side_effect = exception.CoriolisException
+        self.assertRaises(exception.CoriolisException, self.conn.download_file,
+                          self.url, self.remote_path)
+        self.conn.exec_ps_command.assert_called_once()
+
+    def test_write_file(self):
+        self.conn.exec_ps_command = mock.Mock()
+        self.conn.write_file(self.remote_path, b'file content')
+        self.conn.exec_ps_command.assert_called_once_with(
+            "[IO.File]::WriteAllBytes('%s', [Convert]::FromBase64String('%s'))"
+            % (self.remote_path, 'ZmlsZSBjb250ZW50'), ignore_stdout=True)

--- a/coriolis/utils.py
+++ b/coriolis/utils.py
@@ -469,7 +469,7 @@ def get_ssl_cert_thumbprint(context, host, port=443, digest_algorithm="sha1"):
     sock.close()
 
     x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_ASN1, cert)
-    return x509.digest('sha1').decode()
+    return x509.digest(digest_algorithm).decode()
 
 
 def get_resources_dir():


### PR DESCRIPTION
This PR adds more unit testing for the following modules:

* `rpc.py`
* `schemas.py`
* `secrets.py`
* `service.py`
* `utils.py`
* `wsman.py`