### PR TITLE
Various OS upgrade fixes

### DIFF
--- a/coriolis/osmorphing/osmount/redhat.py
+++ b/coriolis/osmorphing/osmount/redhat.py
@@ -25,5 +25,5 @@ class RedHatOSMountTools(base.BaseLinuxOSMountTools):
 
     def _allow_ssh_env_vars(self):
         self._exec_cmd('sudo sed -i -e "\$aAcceptEnv *" /etc/ssh/sshd_config')
-        self._exec_cmd("sudo service sshd reload")
+        utils.restart_service(self._ssh, "sshd")
         return True

--- a/coriolis/osmorphing/osmount/ubuntu.py
+++ b/coriolis/osmorphing/osmount/ubuntu.py
@@ -23,5 +23,5 @@ class UbuntuOSMountTools(base.BaseLinuxOSMountTools):
 
     def _allow_ssh_env_vars(self):
         self._exec_cmd('sudo sed -i -e "\$aAcceptEnv *" /etc/ssh/sshd_config')
-        self._exec_cmd("sudo service ssh reload")
+        utils.restart_service(self._ssh, "sshd")
         return True

--- a/coriolis/providers/replicator.py
+++ b/coriolis/providers/replicator.py
@@ -711,6 +711,14 @@ class Replicator(object):
             },
         }
 
+    def _change_binary_se_context(self, ssh):
+        cmd = "sudo chcon -t bin_t %s" % REPLICATOR_PATH
+        try:
+            utils.exec_ssh_cmd(ssh, cmd, get_pty=True)
+        except exception.CoriolisException:
+            LOG.warn("Could not change SELinux context of replicator binary. "
+                     "Error was:%s", utils.get_exception_details())
+
     @utils.retry_on_error()
     def _setup_replicator(self, ssh):
         # copy the binary, set up the service, generate certificates,
@@ -723,6 +731,7 @@ class Replicator(object):
 
         args = self._parse_replicator_conn_info(self._conn_info)
         self._copy_replicator_cmd(ssh)
+        self._change_binary_se_context(ssh)
         group_existed = self._setup_replicator_group(
             ssh, group_name=REPLICATOR_GROUP_NAME)
         if not group_existed:


### PR DESCRIPTION
This PR includes some fixes required on modern OS images:

- Fix SSH reload on OSMorphing worker

  Fixes SSH daemon restart on newer versions of Linux OSMorphing workers by using
  `systemctl`, if available. Formerly, `service` command was used by default,
  which is no longer available on newer images.

- Set binary context on replicator binary

  Sets valid SELinux file context for the copied `replicator` service binary, in
  order for the service to start on a SELinux-enabled worker machine.