### PR TITLE
Add unit tests for `osmorphing` module

### DIFF
--- a/coriolis/tests/osmorphing/test_amazon.py
+++ b/coriolis/tests/osmorphing/test_amazon.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+
+from coriolis.osmorphing import amazon
+from coriolis.tests import test_base
+
+
+class BaseAmazonLinuxOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseAmazonLinuxOSMorphingTools class."""
+
+    def test_check_os_supported(self):
+        detected_os_info = {
+            "distribution_name": amazon.AMAZON_DISTRO_NAME_IDENTIFIER,
+            "release_version": "2"
+        }
+
+        result = amazon.BaseAmazonLinuxOSMorphingTools.check_os_supported(
+            detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        detected_os_info = {
+            "distribution_name": 'unsupported',
+        }
+        result = amazon.BaseAmazonLinuxOSMorphingTools.check_os_supported(
+            detected_os_info)
+
+        self.assertFalse(result)

--- a/coriolis/tests/osmorphing/test_base.py
+++ b/coriolis/tests/osmorphing/test_base.py
@@ -1,0 +1,975 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+import os
+from unittest import mock
+
+import ddt
+
+from coriolis import exception
+from coriolis.osmorphing import base
+from coriolis.tests import test_base
+
+
+class CoriolisTestException(Exception):
+    pass
+
+
+class BaseOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseOSMorphingTools class."""
+
+    @mock.patch.object(base.BaseOSMorphingTools, '__abstractmethods__', set())
+    @mock.patch.object(
+        base.BaseOSMorphingTools, 'get_required_detected_os_info_fields'
+    )
+    def setUp(self, mock_get_required_fields):
+        super(BaseOSMorphingToolsTestBase, self).setUp()
+        mock_get_required_fields.return_value = [
+            'distribution_name', 'release_version'
+        ]
+        self.detected_os_info = {
+            'distribution_name': mock.sentinel.distribution_name,
+            'release_version': mock.sentinel.release_version,
+        }
+        self.os_morphing_tools = base.BaseOSMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_device, mock.sentinel.hypervisor,
+            mock.sentinel.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters,
+            mock.sentinel.operation_timeout)
+
+    def test_get_required_detected_os_info_fields(self):
+        self.assertRaises(
+            NotImplementedError,
+            base.BaseOSMorphingTools.get_required_detected_os_info_fields
+        )
+
+    @mock.patch.object(
+        base.BaseOSMorphingTools, 'get_required_detected_os_info_fields'
+    )
+    def test_check_detected_os_info_parameters(self, mock_get_required_fields):
+        mock_get_required_fields.return_value = [
+            'distribution_name', 'release_version'
+        ]
+        result = base.BaseOSMorphingTools.check_detected_os_info_parameters(
+            self.detected_os_info)
+
+        mock_get_required_fields.assert_called_once_with()
+
+        self.assertTrue(result)
+
+    @mock.patch.object(
+        base.BaseOSMorphingTools, 'get_required_detected_os_info_fields'
+    )
+    def test_check_detected_os_info_parameters_missing_os_info_fields(
+            self, mock_get_required_fields):
+        mock_get_required_fields.return_value = [
+            'distribution_name', 'release_version'
+        ]
+        # Remove the release_version field in order to trigger the exception.
+        self.detected_os_info.pop('release_version')
+        self.assertRaises(
+            exception.InvalidDetectedOSParams,
+            base.BaseOSMorphingTools.check_detected_os_info_parameters,
+            self.detected_os_info
+        )
+        mock_get_required_fields.assert_called_once_with()
+
+    @mock.patch.object(
+        base.BaseOSMorphingTools, 'get_required_detected_os_info_fields'
+    )
+    def test_check_detected_os_info_parameters_missing_extra_os_info_fields(
+            self, mock_get_required_fields):
+        # Add an extra field in the detected OS info in order to trigger the
+        # exception.
+        self.detected_os_info['extra_field'] = mock.sentinel.extra_field
+        self.assertRaises(
+            exception.InvalidDetectedOSParams,
+            base.BaseOSMorphingTools.check_detected_os_info_parameters,
+            self.detected_os_info
+        )
+        mock_get_required_fields.assert_called_once_with()
+
+    def test_check_os_supported_not_implemented(self):
+        self.assertRaises(
+            NotImplementedError,
+            base.BaseOSMorphingTools.check_os_supported,
+            self.detected_os_info
+        )
+
+    def test_set_environment(self):
+        self.os_morphing_tools.set_environment(mock.sentinel.environment)
+        self.assertEqual(
+            self.os_morphing_tools._environment, mock.sentinel.environment)
+
+
+# This class is used to test the BaseLinuxOSMorphingTools class since it is
+# abstract and cannot be instantiated directly.
+class TestLinuxOSMorphingTools(base.BaseLinuxOSMorphingTools):
+    def check_os_supported(self):
+        pass
+
+    def install_packages(self):
+        pass
+
+    def set_net_config(self):
+        pass
+
+    def uninstall_packages(self):
+        pass
+
+
+@ddt.ddt
+class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseLinuxOSMorphingTools class."""
+
+    def setUp(self):
+        super(BaseLinuxOSMorphingToolsTestBase, self).setUp()
+        self.conn = mock.sentinel.conn
+        self.os_root_dir = '/root'
+        self.chroot_path = '/root/etc/resolv.conf'
+        self.os_root_device = mock.sentinel.os_root_device
+        self.hypervisor = mock.sentinel.hypervisor
+        self.event_manager = mock.MagicMock()
+        self.detected_os_info = {
+            'distribution_name': mock.sentinel.distribution_name,
+            'release_version': mock.sentinel.release_version,
+            'os_type': mock.sentinel.os_type,
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.osmorphing_parameters = mock.sentinel.osmorphing_parameters
+        self.operation_timeout = mock.sentinel.operation_timeout
+        self.os_morphing_tools = TestLinuxOSMorphingTools(
+            self.conn, self.os_root_dir, self.os_root_device, self.hypervisor,
+            self.event_manager, self.detected_os_info,
+            self.osmorphing_parameters, self.operation_timeout)
+
+    @ddt.data(
+        (None, None, None, False),
+        ("1.0", 2.0, None, False),
+        ("2.0", 2.0, 2.0, True),
+        ("3.0", 2.0, 2.5, False),
+        ("2.5", 2.0, 3.0, True)
+    )
+    @ddt.unpack
+    def test__version_supported_util(self, version, min_version, max_version,
+                                     expected_result):
+        result = self.os_morphing_tools._version_supported_util(
+            version, min_version, max_version)
+        self.assertEqual(result, expected_result)
+
+    @ddt.data(
+        (1.0, 2.0, ValueError),
+    )
+    @ddt.unpack
+    def test__version_supported_util_exceptions(self, version, minimum,
+                                                expected_exception):
+        self.assertRaises(
+            expected_exception,
+            self.os_morphing_tools._version_supported_util, version, minimum)
+
+    def test_version_supported_util_warnings_no_match(self):
+        version = "no match"
+        minimum = 1.0
+        with self.assertLogs('coriolis.osmorphing.base', level=logging.WARN):
+            result = base.BaseLinuxOSMorphingTools._version_supported_util(
+                version, minimum)
+        self.assertFalse(result)
+
+    def test_get_packages(self):
+        self.os_morphing_tools._packages = {
+            None: [('pkg1', False), ('pkg2', True)],
+            'hypervisor1': [('pkg3', False)],
+            'hypervisor2': [('pkg4', True)]
+        }
+        self.os_morphing_tools._hypervisor = 'hypervisor1'
+
+        add, remove = self.os_morphing_tools.get_packages()
+
+        self.assertEqual(add, ['pkg1', 'pkg2', 'pkg3'])
+        self.assertEqual(remove, ['pkg2', 'pkg4'])
+
+    def test_get_packages_no_hypervisor(self):
+        self.os_morphing_tools._packages = {
+            None: [('pkg1', False), ('pkg2', True)]
+        }
+        self.os_morphing_tools._hypervisor = None
+
+        add, remove = self.os_morphing_tools.get_packages()
+
+        self.assertEqual(add, ['pkg1', 'pkg2'])
+        self.assertEqual(remove, ['pkg2'])
+
+    @mock.patch.object(base.utils, 'write_ssh_file')
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test_run_user_script_empty_script(self, mock_exec_ssh_cmd,
+                                          mock_write_ssh_file):
+        result = self.os_morphing_tools.run_user_script('')
+        self.assertIsNone(result)
+        mock_write_ssh_file.assert_not_called()
+        mock_exec_ssh_cmd.assert_not_called()
+
+    @mock.patch.object(base.utils, 'write_ssh_file')
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test_run_user_script(self, mock_exec_ssh_cmd, mock_write_ssh_file):
+        user_script = 'echo "Hello, World!"'
+        script_path = '/tmp/coriolis_user_script'
+
+        self.os_morphing_tools.run_user_script(user_script)
+        mock_write_ssh_file.assert_called_once_with(
+            self.conn, script_path, user_script)
+        mock_exec_ssh_cmd.assert_has_calls([
+            mock.call(self.conn, "sudo chmod +x %s" % script_path,
+                      get_pty=True),
+            mock.call(self.conn, 'sudo "%s" "%s"' % (
+                script_path, self.os_morphing_tools._os_root_dir),
+                get_pty=True)])
+
+    @mock.patch.object(base.utils, 'write_ssh_file')
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test_run_user_script_with_exception(self, mock_exec_ssh_cmd,
+                                            mock_write_ssh_file):
+        user_script = 'echo "Hello, World!"'
+        mock_write_ssh_file.side_effect = exception.CoriolisException
+
+        self.assertRaises(
+            exception.CoriolisException,
+            self.os_morphing_tools.run_user_script, user_script)
+        mock_exec_ssh_cmd.assert_not_called()
+
+    @mock.patch.object(base.utils, 'write_ssh_file')
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test_run_user_script_with_exception_on_chmod(self, mock_exec_ssh_cmd,
+                                                     mock_write_ssh_file):
+        user_script = 'echo "Hello, World!"'
+        script_path = '/tmp/coriolis_user_script'
+
+        mock_exec_ssh_cmd.side_effect = exception.CoriolisException
+
+        self.assertRaises(
+            exception.CoriolisException,
+            self.os_morphing_tools.run_user_script, user_script)
+
+        mock_write_ssh_file.assert_called_once_with(
+            self.conn, script_path, user_script)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_copy_resolv_conf')
+    def test_pre_packages_install(self, mock_copy_resolv_conf):
+        self.os_morphing_tools.pre_packages_install(mock.sentinel.package_name)
+        mock_copy_resolv_conf.assert_called_once_with()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_restore_resolv_conf')
+    def test_post_packages_install(self, mock_restore_resolv_conf):
+        self.os_morphing_tools.post_packages_install(
+            mock.sentinel.package_name)
+        mock_restore_resolv_conf.assert_called_once_with()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_copy_resolv_conf')
+    def test_pre_packages_uninstall(self, mock_copy_resolv_conf):
+        self.os_morphing_tools.pre_packages_uninstall(
+            mock.sentinel.package_name)
+        mock_copy_resolv_conf.assert_called_once_with()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_restore_resolv_conf')
+    def test_post_packages_uninstall(self, mock_restore_resolv_conf):
+        self.os_morphing_tools.post_packages_uninstall(
+            mock.sentinel.package_name)
+        mock_restore_resolv_conf.assert_called_once_with()
+
+    def test_get_update_grub2_command(self):
+        self.assertRaises(NotImplementedError,
+                          self.os_morphing_tools.get_update_grub2_command)
+
+    @mock.patch.object(base.utils, 'test_ssh_path')
+    def test__test_path(self, mock_test_ssh_path):
+        result = self.os_morphing_tools._test_path(self.chroot_path)
+
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+
+        mock_test_ssh_path.assert_called_once_with(
+            self.os_morphing_tools._ssh, mocked_full_path)
+        self.assertEqual(result, mock_test_ssh_path.return_value)
+
+    @mock.patch.object(base.utils, 'read_ssh_file')
+    def test__read_file(self, mock_read_ssh_file):
+        result = self.os_morphing_tools._read_file(self.chroot_path)
+
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+
+        mock_read_ssh_file.assert_called_once_with(
+            self.os_morphing_tools._ssh, mocked_full_path)
+        self.assertEqual(result, mock_read_ssh_file.return_value)
+
+    @mock.patch.object(base.utils, 'write_ssh_file')
+    def test__write_file(self, mock_write_ssh_file):
+        self.os_morphing_tools._write_file(
+            self.chroot_path, mock.sentinel.content)
+
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+
+        mock_write_ssh_file.assert_called_once_with(
+            self.os_morphing_tools._ssh, mocked_full_path,
+            mock.sentinel.content)
+
+    @mock.patch.object(base.utils, 'list_ssh_dir')
+    def test__list_dir(self, mock_list_ssh_dir):
+        result = self.os_morphing_tools._list_dir(self.chroot_path)
+
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+
+        mock_list_ssh_dir.assert_called_once_with(
+            self.os_morphing_tools._ssh, mocked_full_path)
+        self.assertEqual(result, mock_list_ssh_dir.return_value)
+
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test__exec_cmd(self, mock_exec_ssh_cmd):
+        result = self.os_morphing_tools._exec_cmd(
+            mock.sentinel.cmd, timeout=120)
+
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.os_morphing_tools._ssh, mock.sentinel.cmd,
+            environment=self.os_morphing_tools._environment, get_pty=True,
+            timeout=120)
+
+        self.assertEqual(result, mock_exec_ssh_cmd.return_value)
+
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test__exec_cmd_without_timeout(self, mock_exec_ssh_cmd):
+        result = self.os_morphing_tools._exec_cmd(mock.sentinel.cmd)
+
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.os_morphing_tools._ssh, mock.sentinel.cmd,
+            environment=self.os_morphing_tools._environment, get_pty=True,
+            timeout=self.os_morphing_tools._osmorphing_operation_timeout)
+        self.assertEqual(result, mock_exec_ssh_cmd.return_value)
+
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test__exec_cmd_with_exception(self, mock_exec_ssh_cmd):
+        mock_exec_ssh_cmd.side_effect = exception.MinionMachineCommandTimeout()
+
+        self.assertRaises(
+            exception.OSMorphingSSHOperationTimeout,
+            self.os_morphing_tools._exec_cmd, mock.sentinel.cmd)
+
+    @mock.patch.object(base.utils, 'exec_ssh_cmd_chroot')
+    def test__exec_cmd_chroot(self, mock_exec_ssh_cmd_chroot):
+        result = self.os_morphing_tools._exec_cmd_chroot(
+            mock.sentinel.cmd, timeout=120)
+
+        mock_exec_ssh_cmd_chroot.assert_called_once_with(
+            self.os_morphing_tools._ssh, self.os_morphing_tools._os_root_dir,
+            mock.sentinel.cmd, environment=self.os_morphing_tools._environment,
+            get_pty=True, timeout=120)
+        self.assertEqual(result, mock_exec_ssh_cmd_chroot.return_value)
+
+    @mock.patch.object(base.utils, 'exec_ssh_cmd_chroot')
+    def test__exec_cmd_chroot_without_timeout(self, mock_exec_ssh_cmd_chroot):
+        result = self.os_morphing_tools._exec_cmd_chroot(mock.sentinel.cmd)
+
+        mock_exec_ssh_cmd_chroot.assert_called_once_with(
+            self.os_morphing_tools._ssh, self.os_morphing_tools._os_root_dir,
+            mock.sentinel.cmd, environment=self.os_morphing_tools._environment,
+            get_pty=True,
+            timeout=self.os_morphing_tools._osmorphing_operation_timeout)
+        self.assertEqual(result, mock_exec_ssh_cmd_chroot.return_value)
+
+    @mock.patch.object(base.utils, 'exec_ssh_cmd_chroot')
+    def test__exec_cmd_chroot_with_exception(self, mock_exec_ssh_cmd_chroot):
+        mock_exec_ssh_cmd_chroot.side_effect = [
+            exception.MinionMachineCommandTimeout()]
+
+        self.assertRaises(
+            exception.OSMorphingSSHOperationTimeout,
+            self.os_morphing_tools._exec_cmd_chroot, mock.sentinel.cmd)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__check_user_exists(self, mock_exec_cmd_chroot):
+        result = self.os_morphing_tools._check_user_exists(
+            mock.sentinel.username)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'id -u %s' % mock.sentinel.username)
+        self.assertTrue(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__check_user_exists_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = CoriolisTestException()
+
+        result = self.os_morphing_tools._check_user_exists(
+            mock.sentinel.username)
+        self.assertFalse(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.uuid, 'uuid4')
+    @mock.patch.object(base.utils, 'exec_ssh_cmd')
+    def test__write_file_sudo(self, mock_exec_ssh_cmd, mock_uuid,
+                              mock_exec_cmd, mock_write_file):
+        self.os_morphing_tools._write_file_sudo(
+            mock.sentinel.chroot_path, mock.sentinel.content)
+
+        mock_write_file.assert_called_once_with(
+            'tmp/%s' % mock_uuid.return_value, mock.sentinel.content)
+        mock_exec_cmd.assert_has_calls([
+            mock.call('cp /tmp/%s /%s' % (
+                mock_uuid.return_value, mock.sentinel.chroot_path)),
+            mock.call('rm /tmp/%s' % mock_uuid.return_value)])
+        mock_exec_ssh_cmd.assert_called_once_with(
+            self.os_morphing_tools._ssh, 'sudo sync',
+            self.os_morphing_tools._environment, get_pty=True)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__enable_systemd_service(self, mock_exec_cmd_chroot):
+        self.os_morphing_tools._enable_systemd_service(
+            mock.sentinel.service_name)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'systemctl enable %s.service' % mock.sentinel.service_name)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__disable_systemd_service(self, mock_exec_cmd_chroot):
+        self.os_morphing_tools._disable_systemd_service(
+            mock.sentinel.service_name)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'systemctl disable %s.service' % mock.sentinel.service_name)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__disable_upstart_service(self, mock_exec_cmd_chroot):
+        self.os_morphing_tools._disable_upstart_service(
+            mock.sentinel.service_name)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'echo manual | tee /etc/init/%s.override' %
+            mock.sentinel.service_name)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_config_file')
+    def test__get_os_release(self, mock_read_config_file):
+        result = self.os_morphing_tools._get_os_release()
+
+        mock_read_config_file.assert_called_once_with(
+            'etc/os-release', check_exists=True)
+        self.assertEqual(result, mock_read_config_file.return_value)
+
+    @mock.patch.object(base.utils, 'read_ssh_ini_config_file')
+    def test__read_config_file(self, mock_read_ssh_ini):
+        result = self.os_morphing_tools._read_config_file(
+            self.chroot_path, check_exists=False)
+
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+        mock_read_ssh_ini.assert_called_once_with(
+            self.os_morphing_tools._ssh, mocked_full_path, check_exists=False)
+        self.assertEqual(result, mock_read_ssh_ini.return_value)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    def test__copy_resolv_conf(self, mock_exec_cmd, mock_test_path):
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+        resolv_conf_path_old = "%s.old" % mocked_full_path
+        mock_test_path.return_value = True
+
+        self.os_morphing_tools._copy_resolv_conf()
+
+        mock_test_path.assert_called_once_with(mocked_full_path)
+        mock_exec_cmd.assert_has_calls([
+            mock.call('sudo mv -f %s %s' % (
+                mocked_full_path, resolv_conf_path_old)),
+            mock.call('sudo cp -L --remove-destination /etc/resolv.conf %s' %
+                      mocked_full_path)])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    def test__restore_resolv_conf(self, mock_exec_cmd, mock_test_path):
+        mocked_full_path = os.path.join(
+            self.os_morphing_tools._os_root_dir, self.chroot_path)
+        resolv_conf_path_old = "%s.old" % mocked_full_path
+        mock_test_path.return_value = True
+
+        self.os_morphing_tools._restore_resolv_conf()
+
+        mock_test_path.assert_called_once_with(resolv_conf_path_old)
+        mock_exec_cmd.assert_called_once_with(
+            'sudo mv -f %s %s' % (resolv_conf_path_old, mocked_full_path))
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__replace_fstab_entries_device_prefix(
+            self, mock_exec_cmd_chroot, mock_write_file, mock_read_file):
+        fstab_chroot_path = "etc/fstab"
+        current_prefix = "/dev/sd"
+        new_prefix = "/dev/vd"
+
+        mock_read_file.return_value = (
+            b"/dev/sda1 / ext4 defaults 0 0\n"
+            b"/dev/sdb1 /home ext4 defaults 0 0")
+
+        self.os_morphing_tools._replace_fstab_entries_device_prefix(
+            current_prefix, new_prefix)
+
+        mock_read_file.assert_called_once_with(fstab_chroot_path)
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "mv -f /%s /%s.bak" % (fstab_chroot_path, fstab_chroot_path))
+        mock_write_file.assert_called_once_with(
+            fstab_chroot_path,
+            "/dev/vda1 / ext4 defaults 0 0\n/dev/vdb1 /home ext4 defaults 0 0")
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__set_selinux_autorelabel(self, mock_exec_cmd_chroot):
+        self.os_morphing_tools._set_selinux_autorelabel()
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'touch /.autorelabel')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__set_selinux_autorelabel_with_exception(self,
+                                                     mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = CoriolisTestException()
+
+        with self.assertLogs('coriolis.osmorphing.base',
+                             level=logging.WARNING):
+            self.os_morphing_tools._set_selinux_autorelabel()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    def test__configure_cloud_init_user_retention(
+            self, mock_read_file, mock_test_path, mock_write_file_sudo,
+            mock_exec_cmd_chroot):
+        cloud_cfg_paths = ["/etc/cloud/cloud.cfg"]
+        cloud_cfgs_dir = "/etc/cloud/cloud.cfg.d"
+
+        mock_test_path.return_value = True
+        mock_exec_cmd_chroot.return_value = b"10.cfg\n20.cfg"
+        mock_read_file.return_value = (
+            b"disable_root: true\n"
+            b"ssh_pwauth: false\nusers: ['user1', 'user2']")
+        self.os_morphing_tools._configure_cloud_init_user_retention()
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call('ls -1 %s' % cloud_cfgs_dir),
+            mock.call('cp %s %s.bak' % (
+                cloud_cfg_paths[0], cloud_cfg_paths[0])),
+            mock.call('cp %s/10.cfg %s/10.cfg.bak' % (
+                cloud_cfgs_dir, cloud_cfgs_dir)),
+            mock.call('cp %s/20.cfg %s/20.cfg.bak' % (
+                cloud_cfgs_dir, cloud_cfgs_dir)),
+        ])
+        mock_test_path.assert_has_calls([
+            mock.call('/etc/cloud/cloud.cfg.d'),
+            mock.call('/etc/cloud/cloud.cfg'),
+            mock.call('/etc/cloud/cloud.cfg.d/10.cfg'),
+            mock.call('/etc/cloud/cloud.cfg.d/20.cfg'),
+        ])
+
+        mock_write_file_sudo.assert_has_calls([
+            mock.call('/etc/cloud/cloud.cfg',
+                      'disable_root: false\nssh_pwauth: true\nusers: null\n'),
+            mock.call('/etc/cloud/cloud.cfg.d/10.cfg',
+                      'disable_root: false\nssh_pwauth: true\nusers: null\n'),
+            mock.call('/etc/cloud/cloud.cfg.d/20.cfg',
+                      'disable_root: false\nssh_pwauth: true\nusers: null\n'),
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    def test__configure_cloud_init_user_retention_path_not_found(
+            self, mock_test_path, mock_exec_cmd_chroot, mock_write_file_sudo):
+        mock_test_path.return_value = False
+
+        with self.assertLogs('coriolis.osmorphing.base', level=logging.WARN):
+            self.os_morphing_tools._configure_cloud_init_user_retention()
+
+        mock_test_path.assert_has_calls([
+            mock.call('/etc/cloud/cloud.cfg.d'),
+            mock.call('/etc/cloud/cloud.cfg'),
+        ])
+        mock_exec_cmd_chroot.assert_not_called()
+        mock_write_file_sudo.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    def test__configure_cloud_init_user_retention_exception(
+            self, mock_test_path, mock_exec_cmd_chroot, mock_read_file,
+            mock_write_file_sudo):
+        mock_test_path.return_value = True
+        mock_exec_cmd_chroot.return_value = b""
+        mock_read_file.return_value = (
+            b"disable_root: true"
+            b"nssh_pwauth: false"
+            b"users: ['user1', 'user2']")
+        mock_write_file_sudo.side_effect = Exception()
+
+        self.assertRaises(
+            exception.CoriolisException,
+            self.os_morphing_tools._configure_cloud_init_user_retention)
+
+        mock_test_path.assert_has_calls([
+            mock.call('/etc/cloud/cloud.cfg.d'),
+            mock.call('/etc/cloud/cloud.cfg'),
+        ])
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call('ls -1 /etc/cloud/cloud.cfg.d'),
+            mock.call('cp /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak'),
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__test_path_chroot(self, mock_exec_cmd_chroot):
+        path = "/tmp/test_path"
+        mock_exec_cmd_chroot.return_value = b"1\n"
+
+        result = self.os_morphing_tools._test_path_chroot(path)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            '[ -f "%s" ] && echo 1 || echo 0' % path)
+        self.assertTrue(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__test_path_chroot_no_leading_slash(self, mock_exec_cmd_chroot):
+        path = "tmp/test_path"
+        mock_exec_cmd_chroot.return_value = b"1\n"
+
+        result = self.os_morphing_tools._test_path_chroot(path)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            '[ -f "/%s" ] && echo 1 || echo 0' % path)
+        self.assertTrue(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__read_file_sudo(self, mock_exec_cmd_chroot):
+        chroot_path = "/tmp/test_path"
+
+        result = self.os_morphing_tools._read_file_sudo(chroot_path)
+
+        mock_exec_cmd_chroot.assert_called_once_with('cat %s' % chroot_path)
+        self.assertEqual(result, mock_exec_cmd_chroot.return_value)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__read_file_sudo_no_leading_slash(self, mock_exec_cmd_chroot):
+        chroot_path = "tmp/test_path"
+
+        result = self.os_morphing_tools._read_file_sudo(chroot_path)
+
+        mock_exec_cmd_chroot.assert_called_once_with('cat /%s' % chroot_path)
+        self.assertEqual(result, mock_exec_cmd_chroot.return_value)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__read_grub_config_file_exists(self, mock_test_path_chroot,
+                                           mock_read_file_sudo):
+        config = mock.sentinel.config
+        file_contents = b'key1="value1"\n#comment\nkey2="value2"\ninvalid_line'
+
+        mock_test_path_chroot.return_value = True
+        mock_read_file_sudo.return_value = file_contents
+
+        result = self.os_morphing_tools._read_grub_config(config)
+
+        mock_test_path_chroot.assert_called_once_with(config)
+        mock_read_file_sudo.assert_called_once_with(config)
+        self.assertEqual(result, {'key1': 'value1', 'key2': 'value2'})
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__read_grub_config_file_not_exists(
+            self, mock_test_path_chroot, mock_read_file_sudo):
+        mock_test_path_chroot.return_value = False
+
+        self.assertRaises(IOError, self.os_morphing_tools._read_grub_config,
+                          mock.sentinel.config)
+
+        mock_read_file_sudo.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_grub_config')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub_config_obj_file_exists(
+            self, mock_test_path_chroot, mock_exec_cmd_chroot,
+            mock_read_grub_config):
+        grub_conf = "/etc/default/grub"
+        tmp_file = "/tmp/tmp_file"
+
+        mock_test_path_chroot.return_value = True
+        mock_exec_cmd_chroot.side_effect = [tmp_file.encode(), None]
+        mock_read_grub_config.return_value = (
+            mock_exec_cmd_chroot.return_value)
+
+        result = self.os_morphing_tools._get_grub_config_obj(grub_conf)
+
+        mock_test_path_chroot.assert_called_once_with(grub_conf)
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call('mktemp'),
+            mock.call('/bin/cp -fp %s %s' % (grub_conf, tmp_file))
+        ])
+        mock_read_grub_config.assert_called_once_with(tmp_file)
+
+        expected_result = {
+            'source': grub_conf,
+            'location': tmp_file,
+            'contents': mock_read_grub_config.return_value
+        }
+
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_grub_config')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub_config_obj_file_not_exists(
+            self, mock_test_path_chroot, mock_exec_cmd_chroot,
+            mock_read_grub_config):
+        grub_conf = "/etc/default/grub"
+
+        mock_test_path_chroot.return_value = False
+
+        self.assertRaises(
+            IOError, self.os_morphing_tools._get_grub_config_obj, grub_conf)
+
+        mock_exec_cmd_chroot.assert_not_called()
+        mock_read_grub_config.assert_not_called()
+
+    def test__validate_grub_config_obj_not_dict(self):
+        config_obj = "invalid config_obj"
+
+        self.assertRaises(ValueError,
+                          self.os_morphing_tools._validate_grub_config_obj,
+                          config_obj)
+
+    def test__validate_grub_config_obj_valid(self):
+        config_obj = {
+            'location': mock.sentinel.location,
+            'source': mock.sentinel.source,
+            'contents': mock.sentinel.contents
+        }
+
+        # Should not raise any exceptions
+        self.os_morphing_tools._validate_grub_config_obj(config_obj)
+
+    def test__validate_grub_config_obj_missing_keys(self):
+        config_obj = {'location': mock.sentinel.location}
+
+        self.assertRaises(ValueError,
+                          self.os_morphing_tools._validate_grub_config_obj,
+                          config_obj)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_set_grub_value_append(self, mock_exec_cmd_chroot,
+                                   mock_read_file_sudo):
+        option = 'option'
+        value = 'value'
+        config_obj = {
+            'location': '/tmp/tmp_file',
+            'source': '/etc/default/grub',
+            'contents': {
+                'GRUB_DEFAULT': '0'
+            },
+        }
+        cfg = 'cfg'
+
+        mock_read_file_sudo.return_value = cfg.encode()
+
+        self.os_morphing_tools.set_grub_value(option, value, config_obj)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'sed -ie \'$a%s="%s"\' %s' % (
+                option, value, config_obj['location'])
+        )
+        mock_read_file_sudo.assert_called_once_with(config_obj['location'])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_set_grub_value_replace(self, mock_exec_cmd_chroot,
+                                    mock_read_file_sudo):
+        option = 'option'
+        value = 'value'
+        config_obj = {
+            'location': '/tmp/tmp_file',
+            'source': '/etc/default/grub',
+            'contents': {option: 'old_value'},
+        }
+        cfg = 'cfg'
+
+        mock_read_file_sudo.return_value = cfg.encode()
+
+        self.os_morphing_tools.set_grub_value(option, value, config_obj)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'sed -i \'s|^%s=.*|%s="%s"|g\' %s' % (option, option, value,
+                                                  config_obj['location'])
+        )
+        mock_read_file_sudo.assert_called_once_with(config_obj['location'])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
+    def test__set_grub2_cmdline_clobber(self, mock_set_grub_value):
+        config_obj = {
+            'contents': {
+                'GRUB_CMDLINE_LINUX_DEFAULT': mock.sentinel.default,
+                'GRUB_CMDLINE_LINUX': mock.sentinel.linux,
+            },
+        }
+        options = ['option1', 'option2']
+
+        self.os_morphing_tools._set_grub2_cmdline(config_obj, options,
+                                                  clobber=True)
+
+        mock_set_grub_value.assert_called_once_with(
+            'GRUB_CMDLINE_LINUX', ' '.join(options), config_obj, replace=True)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
+    def test__set_grub2_cmdline_add_options(self, mock_set_grub_value):
+        config_obj = {
+            'contents': {
+                'GRUB_CMDLINE_LINUX_DEFAULT': 'quiet_default',
+                'GRUB_CMDLINE_LINUX': 'quiet_linux',
+            },
+        }
+        options = ['option1', 'option2']
+
+        self.os_morphing_tools._set_grub2_cmdline(config_obj, options,
+                                                  clobber=False)
+
+        mock_set_grub_value.assert_called_once_with(
+            'GRUB_CMDLINE_LINUX', 'quiet_linux option1 option2', config_obj,
+            replace=True)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
+    def test__set_grub2_cmdline_no_options_to_add(self, mock_set_grub_value):
+        config_obj = {
+            'contents': {
+                'GRUB_CMDLINE_LINUX_DEFAULT': 'quiet_option1',
+                'GRUB_CMDLINE_LINUX': 'quiet_option2',
+            },
+        }
+        options = ['option1']
+
+        self.os_morphing_tools._set_grub2_cmdline(config_obj, options,
+                                                  clobber=False)
+        mock_set_grub_value.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(
+        base.BaseLinuxOSMorphingTools, 'get_update_grub2_command'
+    )
+    def test__execute_update_grub(self, mock_get_update_grub2_command,
+                                  mock_exec_cmd_chroot):
+        self.os_morphing_tools._execute_update_grub()
+
+        mock_get_update_grub2_command.assert_called_once_with()
+        mock_exec_cmd_chroot.assert_called_once_with(
+            mock_get_update_grub2_command.return_value
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_execute_update_grub')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__apply_grub2_config(self, mock_exec_cmd_chroot,
+                                 mock_execute_update_grub):
+        config_obj = {
+            'location': mock.sentinel.location,
+            'source': mock.sentinel.source,
+            'contents': {
+                'GRUB_DEFAULT': '0'
+            },
+        }
+
+        self.os_morphing_tools._apply_grub2_config(config_obj,
+                                                   execute_update_grub=True)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'mv -f %s %s' % (config_obj['location'], config_obj['source'])
+        )
+        mock_execute_update_grub.assert_called_once_with()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_execute_update_grub')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__apply_grub2_config_no_update_grub(self, mock_exec_cmd_chroot,
+                                                mock_execute_update_grub):
+        config_obj = {
+            'location': mock.sentinel.location,
+            'source': mock.sentinel.source,
+            'contents': {
+                'GRUB_DEFAULT': '0'
+            },
+        }
+
+        self.os_morphing_tools._apply_grub2_config(config_obj,
+                                                   execute_update_grub=False)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'mv -f %s %s' % (config_obj['location'], config_obj['source'])
+        )
+        mock_execute_update_grub.assert_not_called()
+
+    def test__set_grub2_console_settings_invalid_parity(self):
+        self.assertRaises(
+            ValueError,
+            self.os_morphing_tools._set_grub2_console_settings,
+            parity='invalid_parity')
+
+    def test__set_grub2_console_settings_invalid_consoles(self):
+        self.assertRaises(
+            ValueError, self.os_morphing_tools._set_grub2_console_settings,
+            consoles='invalid_consoles')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_apply_grub2_config')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_set_grub2_cmdline')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_get_grub_config_obj')
+    def test__set_grub2_console_settings_all_params(
+            self, mock_get_grub_config_obj, mock_set_grub_value,
+            mock_set_grub2_cmdline, mock_apply_grub2_config):
+        consoles = ['tty0', 'ttyS0']
+        speed = 9600
+        parity = 'odd'
+        grub_conf = '/etc/default/grub'
+
+        config_obj = {'location': grub_conf}
+        mock_get_grub_config_obj.return_value = config_obj
+
+        serial_cmd = base.GRUB2_SERIAL % (speed, parity)
+
+        self.os_morphing_tools._set_grub2_console_settings(
+            consoles, speed, parity, grub_conf,
+            execute_update_grub=False)
+
+        mock_get_grub_config_obj.assert_called_once_with(grub_conf)
+        mock_set_grub_value.assert_called_once_with(
+            'GRUB_SERIAL_COMMAND', serial_cmd, config_obj)
+        mock_set_grub2_cmdline.assert_called_once_with(
+            config_obj, ['console=tty0', 'console=ttyS0'])
+        mock_apply_grub2_config.assert_called_once_with(
+            config_obj, False)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_apply_grub2_config')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_set_grub2_cmdline')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_get_grub_config_obj')
+    def test__set_grub2_console_settings_default_params(
+            self, mock_get_grub_config_obj, mock_set_grub_value,
+            mock_set_grub2_cmdline, mock_apply_grub2_config):
+        grub_conf = '/etc/default/grub'
+
+        config_obj = {'location': grub_conf}
+        mock_get_grub_config_obj.return_value = config_obj
+
+        self.os_morphing_tools._set_grub2_console_settings(
+            grub_conf=grub_conf, execute_update_grub=True)
+
+        mock_get_grub_config_obj.assert_called_once_with(grub_conf)
+        mock_set_grub_value.assert_called_once_with(
+            'GRUB_SERIAL_COMMAND',
+            'serial --word=8 --stop=1 --speed=115200 --parity=no --unit=0',
+            config_obj)
+        mock_set_grub2_cmdline.assert_called_once_with(
+            config_obj, ['console=tty0', 'console=ttyS0'])
+        mock_apply_grub2_config.assert_called_once_with(config_obj, True)

--- a/coriolis/tests/osmorphing/test_centos.py
+++ b/coriolis/tests/osmorphing/test_centos.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+
+from coriolis.osmorphing import centos
+from coriolis.tests import test_base
+
+
+class BaseCentOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseCentOSMorphingTools class."""
+
+    def test_check_os_supported(self):
+        detected_os_info = {
+            "distribution_name": centos.CENTOS_DISTRO_IDENTIFIER,
+            "release_version": "6"
+        }
+
+        result = centos.BaseCentOSMorphingTools.check_os_supported(
+            detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        detected_os_info = {
+            "distribution_name": 'unsupported',
+        }
+        result = centos.BaseCentOSMorphingTools.check_os_supported(
+            detected_os_info)
+
+        self.assertFalse(result)

--- a/coriolis/tests/osmorphing/test_coreos.py
+++ b/coriolis/tests/osmorphing/test_coreos.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from coriolis.osmorphing import coreos
+from coriolis.osmorphing.osdetect import coreos as coreos_detect
+from coriolis.tests import test_base
+
+
+class BaseCoreOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseCoreOSMorphingTools class."""
+
+    def test_check_os_supported(self):
+        detected_os_info = {
+            "distribution_name": coreos_detect.COREOS_DISTRO_IDENTIFIER
+        }
+        result = coreos.BaseCoreOSMorphingTools.check_os_supported(
+            detected_os_info)
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        detected_os_info = {
+            "distribution_name": "unsupported"
+        }
+        result = coreos.BaseCoreOSMorphingTools.check_os_supported(
+            detected_os_info)
+        self.assertFalse(result)

--- a/coriolis/tests/osmorphing/test_debian.py
+++ b/coriolis/tests/osmorphing/test_debian.py
@@ -1,0 +1,276 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolis import exception
+from coriolis.osmorphing import base
+from coriolis.osmorphing import debian
+from coriolis.tests import test_base
+
+
+class BaseDebianMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseDebianMorphingTools class."""
+
+    def setUp(self):
+        super(BaseDebianMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': debian.DEBIAN_DISTRO_IDENTIFIER,
+            'release_version': '8',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.os_root_dir = '/root'
+        self.nics_info = [{'name': 'eth0'}, {'name': 'eth1'}]
+        self.package_names = ['package1', 'package2']
+        self._event_manager = mock.MagicMock()
+
+        self.morpher = debian.BaseDebianMorphingTools(
+            mock.sentinel.conn, self.os_root_dir, mock.sentinel.os_root_dev,
+            mock.sentinel.hypervisor, self._event_manager,
+            self.detected_os_info, mock.sentinel.osmorphing_parameters,
+            mock.sentinel.osmorphing_config)
+
+    def test_check_os_supported(self):
+        result = debian.BaseDebianMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        self.detected_os_info['distribution_name'] = 'unsupported'
+
+        result = debian.BaseDebianMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    @mock.patch('coriolis.utils.Grub2ConfigEditor')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_test_path')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_write_file_sudo')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_read_file')
+    def test_disable_predictable_nic_names(
+            self, mock_read_file, mock_write_file_sudo, mock_exec_cmd_chroot,
+            mock_test_path, mock_grub2_cfg_editor):
+        mock_test_path.return_value = True
+
+        self.morpher.disable_predictable_nic_names()
+
+        mock_test_path.assert_called_once_with(
+            self.os_root_dir + '/etc/default/grub')
+        mock_grub2_cfg_editor.assert_called_once_with(
+            mock_read_file.return_value.decode.return_value)
+        mock_grub2_cfg_editor.return_value.append_to_option.assert_has_calls(
+            [
+                mock.call(
+                    "GRUB_CMDLINE_LINUX_DEFAULT",
+                    {"opt_type": "key_val", "opt_key": "net.ifnames",
+                     "opt_val": 0}),
+                mock.call(
+                    "GRUB_CMDLINE_LINUX_DEFAULT",
+                    {"opt_type": "key_val", "opt_key": "biosdevname",
+                     "opt_val": 0}),
+                mock.call(
+                    "GRUB_CMDLINE_LINUX",
+                    {"opt_type": "key_val", "opt_key": "net.ifnames",
+                     "opt_val": 0}),
+                mock.call(
+                    "GRUB_CMDLINE_LINUX",
+                    {"opt_type": "key_val", "opt_key": "biosdevname",
+                     "opt_val": 0})
+            ]
+        )
+        mock_read_file.assert_called_once_with(
+            self.os_root_dir + '/etc/default/grub')
+        mock_write_file_sudo.assert_called_once_with(
+            "etc/default/grub", mock_grub2_cfg_editor.return_value.dump())
+        mock_exec_cmd_chroot.assert_called_once_with("/usr/sbin/update-grub")
+
+    @mock.patch('coriolis.utils.Grub2ConfigEditor')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_write_file_sudo')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_read_file')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_test_path')
+    def test_disable_predictable_nic_names_no_test_path(
+            self, mock_test_path, mock_read_file,
+            mock_write_file_sudo, mock_exec_cmd_chroot, mock_grub2_cfg_editor):
+
+        mock_test_path.return_value = False
+
+        self.morpher.disable_predictable_nic_names()
+
+        mock_read_file.assert_not_called()
+        mock_write_file_sudo.assert_not_called()
+        mock_exec_cmd_chroot.assert_not_called()
+        mock_grub2_cfg_editor.assert_not_called()
+
+    def test_get_update_grub2_command(self):
+        result = self.morpher.get_update_grub2_command()
+        self.assertEqual(result, "update-grub")
+
+    def test__compose_interfaces_config(self):
+        result = self.morpher._compose_interfaces_config(self.nics_info)
+
+        expected_result = (
+            "\n"
+            "auto lo\n"
+            "iface lo inet loopback\n"
+            "\n\n\n"
+            "auto eth0\n"
+            "iface eth0 inet dhcp\n"
+            "\n\n\n"
+            "auto eth1\n"
+            "iface eth1 inet dhcp\n"
+            "\n\n"
+        )
+
+        self.assertEqual(result, expected_result)
+
+    def test__compose_netplan_cfg(self):
+        expected_cfg = {
+            "network": {
+                "version": 2,
+                "ethernets": {
+                    "lo": {
+                        "match": {
+                            "name": "lo"
+                        },
+                        "addresses": ["127.0.0.1/8"]
+                    },
+                    "eth0": {
+                        "dhcp4": True,
+                        "dhcp6": True,
+                    },
+                    "eth1": {
+                        "dhcp4": True,
+                        "dhcp6": True,
+                    }
+                }
+            }
+        }
+
+        result = self.morpher._compose_netplan_cfg(self.nics_info)
+
+        expected_result = debian.yaml.dump(
+            expected_cfg, default_flow_style=False)
+
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_write_file_sudo')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_test_path')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_list_dir')
+    @mock.patch.object(
+        debian.BaseDebianMorphingTools, 'disable_predictable_nic_names'
+    )
+    def test_set_net_config(
+            self, mock_disable_predictable_nic_names, mock_list_dir,
+            mock_test_path, mock_exec_cmd_chroot, mock_write_file_sudo):
+        dhcp = True
+        mock_test_path.return_value = True
+        mock_list_dir.return_value = ['file1.yaml', 'file2.yml']
+
+        self.morpher.set_net_config(self.nics_info, dhcp)
+
+        netplan_cfg = self.morpher._compose_netplan_cfg(self.nics_info)
+        interfaces_config = self.morpher._compose_interfaces_config(
+            self.nics_info)
+
+        mock_disable_predictable_nic_names.assert_called_once()
+        mock_test_path.assert_has_calls([
+            mock.call('etc/network'),
+            mock.call('etc/network/interfaces'),
+            mock.call('etc/netplan')])
+        mock_list_dir.assert_called_once_with('etc/netplan')
+        mock_write_file_sudo.assert_has_calls(
+            [mock.call('etc/network/interfaces', interfaces_config),
+             mock.call('etc/netplan/coriolis_netplan.yaml', netplan_cfg)])
+        mock_exec_cmd_chroot.assert_has_calls(
+            [mock.call('cp etc/network/interfaces etc/network/interfaces.bak'),
+             mock.call('mv etc/netplan/file1.yaml etc/netplan/file1.yaml.bak'),
+             mock.call('mv etc/netplan/file2.yml etc/netplan/file2.yml.bak')])
+
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_write_file_sudo')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_test_path')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_list_dir')
+    @mock.patch.object(
+        debian.BaseDebianMorphingTools, 'disable_predictable_nic_names'
+    )
+    def test_set_net_config_no_dhcp(
+            self, mock_disable_predictable_nic_names, mock_list_dir,
+            mock_test_path, mock_exec_cmd_chroot, mock_write_file_sudo):
+        dhcp = False
+
+        self.morpher.set_net_config(self.nics_info, dhcp)
+
+        mock_disable_predictable_nic_names.assert_not_called()
+        mock_test_path.assert_not_called()
+        mock_list_dir.assert_not_called()
+        mock_write_file_sudo.assert_not_called()
+        mock_exec_cmd_chroot.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'pre_packages_install')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    def test_pre_packages_install(self, mock_exec_cmd_chroot,
+                                  mock_pre_packages_install):
+
+        self.morpher.pre_packages_install(self.package_names)
+
+        mock_pre_packages_install.assert_called_once_with(self.package_names)
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call('apt-get clean'),
+            mock.call('apt-get update -y')
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'pre_packages_install')
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    def test_pre_packages_install_with_exception(self, mock_exec_cmd_chroot,
+                                                 mock_pre_packages_install):
+        mock_exec_cmd_chroot.side_effect = Exception()
+
+        self.assertRaises(exception.PackageManagerOperationException,
+                          self.morpher.pre_packages_install,
+                          self.package_names)
+
+        mock_pre_packages_install.assert_called_once_with(self.package_names)
+
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    def test_install_packages(self, mock_exec_cmd_chroot):
+        self.morpher.install_packages(self.package_names)
+
+        apt_get_cmd = (
+            '/bin/bash -c "DEBIAN_FRONTEND=noninteractive '
+            'apt-get install %s -y '
+            '-o Dpkg::Option::=\'--force-confdef\'"' % (
+                " ".join(self.package_names)))
+        deb_reconfigure_cmd = "dpkg --configure --force-confold -a"
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call(deb_reconfigure_cmd),
+            mock.call(apt_get_cmd)
+        ])
+
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    def test_install_packages_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = Exception()
+
+        self.assertRaises(exception.FailedPackageInstallationException,
+                          self.morpher.install_packages, self.package_names)
+
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    def test_uninstall_packages(self, mock_exec_cmd_chroot):
+        self.morpher.uninstall_packages(self.package_names)
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call('apt-get remove %s -y || true' % self.package_names[0]),
+            mock.call('apt-get remove %s -y || true' % self.package_names[1])
+        ])
+
+    @mock.patch.object(debian.BaseDebianMorphingTools, '_exec_cmd_chroot')
+    def test_uninstall_packages_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        self.assertRaises(exception.FailedPackageUninstallationException,
+                          self.morpher.uninstall_packages, self.package_names)

--- a/coriolis/tests/osmorphing/test_manager.py
+++ b/coriolis/tests/osmorphing/test_manager.py
@@ -1,0 +1,334 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+from unittest import mock
+
+from coriolis import exception
+from coriolis.osmorphing import base as base_osmorphing
+from coriolis.osmorphing import manager
+from coriolis.tests import test_base
+
+
+class ManagerTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the Coriolis manager module."""
+
+    def setUp(self):
+        super(ManagerTestCase, self).setUp()
+        self.osmorphing_info = {
+            'os_type': 'linux',
+            'ignore_devices': []
+        }
+        manager.CONF.proxy.url = "http://127.0.0.1:8080"
+        manager.CONF.proxy.username = "admin"
+        manager.CONF.proxy.password = "Random-Password-123!"
+        manager.CONF.proxy.no_proxy = ["cloudbase.it"]
+        manager.CONF.default_osmorphing_operation_timeout = 60
+
+        self.provider = mock.MagicMock()
+        self.event_handler = mock.MagicMock()
+        self.os_mount_tools = mock.MagicMock()
+        self.event_manager = mock.MagicMock()
+        self.destination_provider = mock.MagicMock()
+        self.worker_connection = mock.MagicMock()
+        self.detected_os_info = mock.MagicMock()
+
+    def test_get_proxy_settings(self):
+        expected_result = {
+            "url": "http://127.0.0.1:8080",
+            "username": "admin",
+            "password": "Random-Password-123!",
+            "no_proxy": ["cloudbase.it"],
+        }
+
+        result = manager._get_proxy_settings()
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(manager.osdetect_manager, 'detect_os')
+    def test_run_os_detect(self, mock_detect_os):
+        mock_detect_os.return_value = {
+            "os_type": "linux",
+            "distribution_name": "Ubuntu",
+            "release_version": "22.04",
+            "friendly_release_name": "Ubuntu 22.04",
+        }
+        self.provider.get_custom_os_detect_tools.return_value = [
+            mock.sentinel.os_type]
+        self.destination_provider.get_custom_os_detect_tools.return_value = [
+            mock.sentinel.os_type]
+
+        result = manager.run_os_detect(
+            self.provider, self.destination_provider, self.worker_connection,
+            mock.sentinel.os_type, mock.sentinel.os_root_dir,
+            mock.sentinel.osmorphing_info, tools_environment={})
+
+        self.assertEqual(result, mock_detect_os.return_value)
+
+        self.provider.get_custom_os_detect_tools.\
+            assert_called_once_with(mock.sentinel.os_type,
+                                    mock.sentinel.osmorphing_info)
+        self.destination_provider.get_custom_os_detect_tools.\
+            assert_called_once_with(mock.sentinel.os_type,
+                                    mock.sentinel.osmorphing_info)
+        mock_detect_os.assert_called_once_with(
+            self.worker_connection, mock.sentinel.os_type,
+            mock.sentinel.os_root_dir,
+            60,
+            tools_environment={},
+            custom_os_detect_tools=[mock.sentinel.os_type,
+                                    mock.sentinel.os_type])
+
+    def test_get_osmorphing_tools_class_for_provider(self):
+        class MockToolsClass(base_osmorphing.BaseOSMorphingTools):
+            @classmethod
+            def get_required_detected_os_info_fields(cls):
+                return []
+
+            @classmethod
+            def check_detected_os_info_parameters(cls, detected_os_info):
+                return
+
+            @classmethod
+            def check_os_supported(cls, detected_os_info):
+                return True
+
+        self.provider.get_os_morphing_tools.return_value = [MockToolsClass]
+
+        result = manager.get_osmorphing_tools_class_for_provider(
+            self.provider, mock.sentinel.detected_os_info,
+            mock.sentinel.os_type, mock.sentinel.osmorphing_info)
+
+        self.assertEqual(result, MockToolsClass)
+
+    def test_get_osmorphing_tools_class_for_provider_invalid_tools(self):
+        class MockInvalidToolsClass:
+            pass
+
+        self.provider.get_os_morphing_tools.return_value = [
+            MockInvalidToolsClass]
+
+        self.assertRaises(exception.InvalidOSMorphingTools,
+                          manager.get_osmorphing_tools_class_for_provider,
+                          self.provider, mock.sentinel.detected_os_info,
+                          mock.sentinel.os_type, mock.sentinel.osmorphing_info)
+
+    def test_get_osmorphing_tools_class_for_provider_invalid_os_params(self):
+        class MockToolsClass(base_osmorphing.BaseOSMorphingTools):
+            @classmethod
+            def get_required_detected_os_info_fields(cls):
+                return []
+
+            @classmethod
+            def check_detected_os_info_parameters(cls, detected_os_info):
+                raise exception.InvalidDetectedOSParams()
+
+        self.provider.get_os_morphing_tools.return_value = [MockToolsClass]
+
+        with self.assertLogs(
+            'coriolis.osmorphing.manager', level=logging.WARN):
+            result = manager.get_osmorphing_tools_class_for_provider(
+                self.provider, mock.sentinel.detected_os_info,
+                mock.sentinel.os_type, mock.sentinel.osmorphing_info)
+
+        self.assertIsNone(result)
+
+    def test_get_osmorphing_tools_class_for_provider_os_not_supported(self):
+        class MockToolsClass(base_osmorphing.BaseOSMorphingTools):
+            @classmethod
+            def get_required_detected_os_info_fields(cls):
+                return []
+
+            @classmethod
+            def check_os_supported(cls, detected_os_info):
+                return False
+
+        self.provider.get_os_morphing_tools.return_value = [MockToolsClass]
+
+        with self.assertLogs(
+            'coriolis.osmorphing.manager', level=logging.DEBUG):
+            result = manager.get_osmorphing_tools_class_for_provider(
+                self.provider, self.detected_os_info,
+                mock.sentinel.os_type, mock.sentinel.osmorphing_info)
+
+        self.assertIsNone(result)
+
+    class MockOSMorphingToolsClass:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_environment(self, environment):
+            pass
+
+        def run_user_script(self, user_script):
+            pass
+
+        def get_packages(self):
+            return [['package1'], ['package2']]
+
+        def pre_packages_uninstall(self, packages_remove):
+            pass
+
+        def post_packages_uninstall(self, packages_remove):
+            pass
+
+        def pre_packages_install(self, packages_add):
+            pass
+
+        def set_net_config(self, nics_info, dhcp):
+            pass
+
+        def post_packages_install(self, packages_add):
+            pass
+
+        def install_packages(self, packages_add):
+            pass
+
+        def uninstall_packages(self, packages_remove):
+            pass
+
+    @mock.patch.object(manager.osmount_factory, 'get_os_mount_tools')
+    @mock.patch.object(manager.events, 'EventManager')
+    @mock.patch.object(manager, 'run_os_detect')
+    @mock.patch.object(manager, 'get_osmorphing_tools_class_for_provider')
+    def test_morph_image(
+            self, mock_get_osmorphing_tools_class, mock_run_os_detect,
+            mock_EventManager, mock_get_os_mount_tools):
+        mock_EventManager.return_value = self.event_manager
+        mock_get_os_mount_tools.return_value = self.os_mount_tools
+
+        self.os_mount_tools.mount_os.return_value = (
+            'os_root_dir', 'os_root_dev')
+        mock_run_os_detect.return_value = {'friendly_release_name': 'mock_os'}
+
+        mock_get_osmorphing_tools_class.return_value = (
+            self.MockOSMorphingToolsClass)
+
+        manager.morph_image(
+            mock.sentinel.origin_provider, mock.sentinel.destination_provider,
+            mock.sentinel.connection_info, self.osmorphing_info,
+            mock.sentinel.user_script, self.event_handler)
+
+        expected_calls = [
+            mock.call(
+                mock.sentinel.origin_provider, mock_run_os_detect.return_value,
+                self.osmorphing_info.get('os_type'), self.osmorphing_info),
+            mock.call(
+                mock.sentinel.destination_provider,
+                mock_run_os_detect.return_value,
+                self.osmorphing_info.get('os_type'), self.osmorphing_info)
+        ]
+        mock_get_osmorphing_tools_class.assert_has_calls(expected_calls)
+
+        self.os_mount_tools.setup.assert_called_once()
+        self.os_mount_tools.mount_os.assert_called_once()
+        self.os_mount_tools.dismount_os.assert_called_once()
+
+        mock_get_os_mount_tools.assert_called_once_with(
+            'linux', mock.sentinel.connection_info, self.event_manager, [], 60)
+        mock_EventManager.assert_called_once_with(self.event_handler)
+
+        self.os_mount_tools.dismount_os.assert_called_once()
+
+    @mock.patch.object(manager, 'get_osmorphing_tools_class_for_provider')
+    @mock.patch.object(manager.osmount_factory, 'get_os_mount_tools')
+    @mock.patch.object(manager.events, 'EventManager')
+    def test_morph_image_failed_os_mount_setup(
+            self, mock_EventManager, mock_get_os_mount_tools,
+            mock_get_osmorphing_tools_class):
+        mock_EventManager.return_value = self.event_manager
+        mock_get_os_mount_tools.return_value = self.os_mount_tools
+
+        self.os_mount_tools.setup.side_effect = Exception()
+
+        self.assertRaises(
+            exception.CoriolisException,
+            manager.morph_image, mock.sentinel.origin_provider,
+            mock.sentinel.destination_provider,
+            mock.sentinel.connection_info, self.osmorphing_info,
+            mock.sentinel.user_script,
+            self.event_handler)
+
+        mock_get_os_mount_tools.assert_called_once_with(
+            'linux', mock.sentinel.connection_info, self.event_manager, [], 60)
+        mock_EventManager.assert_called_once_with(self.event_handler)
+
+        mock_get_osmorphing_tools_class.assert_not_called()
+        self.os_mount_tools.mount_os.assert_not_called()
+        self.os_mount_tools.dismount_os.assert_not_called()
+
+    @mock.patch.object(manager.osmount_factory, 'get_os_mount_tools')
+    @mock.patch.object(manager.events, 'EventManager')
+    @mock.patch.object(manager, 'run_os_detect')
+    @mock.patch.object(manager, 'get_osmorphing_tools_class_for_provider')
+    def test_morph_image_no_import_os_morphing_tools_cls(
+            self, mock_get_osmorphing_tools_class, mock_run_os_detect,
+            mock_EventManager, mock_get_os_mount_tools):
+        mock_EventManager.return_value = self.event_manager
+        mock_get_os_mount_tools.return_value = self.os_mount_tools
+
+        self.os_mount_tools.mount_os.return_value = (
+            'os_root_dir', 'os_root_dev')
+        mock_run_os_detect.return_value = {'friendly_release_name': 'mock_os'}
+
+        mock_get_osmorphing_tools_class.return_value = None
+
+        with self.assertLogs(
+            'coriolis.osmorphing.manager', level=logging.ERROR):
+            self.assertRaises(
+                exception.OSMorphingToolsNotFound,
+                manager.morph_image, mock.sentinel.origin_provider,
+                mock.sentinel.destination_provider,
+                mock.sentinel.connection_info, self.osmorphing_info,
+                mock.sentinel.user_script, self.event_handler)
+
+    @mock.patch.object(manager.osmount_factory, 'get_os_mount_tools')
+    @mock.patch.object(manager.events, 'EventManager')
+    @mock.patch.object(manager, 'run_os_detect')
+    @mock.patch.object(manager, 'get_osmorphing_tools_class_for_provider')
+    def test_morph_image_no_user_script(
+            self, mock_get_osmorphing_tools_class, mock_run_os_detect,
+            mock_EventManager, mock_get_os_mount_tools):
+        mock_user_script = None
+
+        mock_EventManager.return_value = self.event_manager
+        mock_get_os_mount_tools.return_value = self.os_mount_tools
+
+        self.os_mount_tools.mount_os.return_value = (
+            'os_root_dir', 'os_root_dev')
+        mock_run_os_detect.return_value = {'friendly_release_name': 'mock_os'}
+
+        mock_get_osmorphing_tools_class.return_value = (
+            self.MockOSMorphingToolsClass)
+
+        manager.morph_image(
+            mock.sentinel.origin_provider, mock.sentinel.destination_provider,
+            mock.sentinel.connection_info, self.osmorphing_info,
+            mock_user_script, self.event_handler)
+
+        mock_get_osmorphing_tools_class.run_user_script.assert_not_called()
+
+    @mock.patch.object(manager.osmount_factory, 'get_os_mount_tools')
+    @mock.patch.object(manager.events, 'EventManager')
+    @mock.patch.object(manager, 'run_os_detect')
+    @mock.patch.object(manager, 'get_osmorphing_tools_class_for_provider')
+    def test_morph_image_dismount_os_exception(
+            self, mock_get_osmorphing_tools_class, mock_run_os_detect,
+            mock_EventManager, mock_get_os_mount_tools):
+        mock_EventManager.return_value = self.event_manager
+        mock_get_os_mount_tools.return_value = self.os_mount_tools
+
+        self.os_mount_tools.mount_os.return_value = (
+            'os_root_dir', 'os_root_dev')
+        mock_run_os_detect.return_value = {'friendly_release_name': 'mock_os'}
+
+        mock_get_osmorphing_tools_class.return_value = (
+            self.MockOSMorphingToolsClass)
+
+        self.os_mount_tools.dismount_os.side_effect = Exception()
+
+        self.assertRaises(
+            exception.CoriolisException,
+            manager.morph_image, mock.sentinel.origin_provider,
+            mock.sentinel.destination_provider,
+            mock.sentinel.connection_info, self.osmorphing_info,
+            mock.sentinel.user_script, self.event_handler)

--- a/coriolis/tests/osmorphing/test_openwrt.py
+++ b/coriolis/tests/osmorphing/test_openwrt.py
@@ -1,0 +1,43 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from coriolis.osmorphing import openwrt
+from coriolis.tests import test_base
+
+
+class MockOpenWRTMorphingTools(openwrt.BaseOpenWRTMorphingTools):
+    def __init__(self):
+        pass
+
+    def install_packages(self, packages):
+        pass
+
+    def uninstall_packages(self, packages):
+        pass
+
+
+class BaseOpenWRTMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test case for the BaseOpenWRTMorphingTools class."""
+
+    def test_check_os_supported(self):
+        detected_os_info = {
+            'distribution_name': openwrt.OPENWRT_DISTRO_IDENTIFIER
+        }
+        result = openwrt.BaseOpenWRTMorphingTools.check_os_supported(
+            detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        detected_os_info = {
+            'distribution_name': 'unsupported'
+        }
+        result = openwrt.BaseOpenWRTMorphingTools.check_os_supported(
+            detected_os_info)
+
+        self.assertFalse(result)
+
+    def test_get_update_grub2_command(self):
+        morphing_tools = MockOpenWRTMorphingTools()
+        self.assertRaises(NotImplementedError,
+                          morphing_tools.get_update_grub2_command)

--- a/coriolis/tests/osmorphing/test_oracle.py
+++ b/coriolis/tests/osmorphing/test_oracle.py
@@ -1,0 +1,92 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from unittest import mock
+
+from coriolis.osmorphing import base
+from coriolis.osmorphing import oracle
+from coriolis.osmorphing.osdetect import oracle as oracle_detect
+from coriolis.osmorphing import redhat
+from coriolis.tests import test_base
+
+
+class BaseOracleMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test case for the BaseOracleMorphingTools class."""
+
+    def setUp(self):
+        super(BaseOracleMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': oracle_detect.ORACLE_DISTRO_IDENTIFIER,
+            'release_version': '6',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.oracle_morphing_tools = oracle.BaseOracleMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
+            mock.sentinel.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters)
+
+    def test_check_os_supported(self):
+        result = oracle.BaseOracleMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        self.detected_os_info['distribution_name'] = 'unsupported'
+
+        result = oracle.BaseOracleMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_find_yum_repos')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
+    def test__get_oracle_repos(self, mock_yum_install, mock_find_yum_repos,
+                               mock_exec_cmd_chroot):
+        self.oracle_morphing_tools._version = '10'
+
+        result = self.oracle_morphing_tools._get_oracle_repos()
+
+        self.assertEqual(result, mock_find_yum_repos.return_value)
+
+        mock_find_yum_repos.assert_has_calls([
+            mock.call(["ol10_baseos_latest"]),
+            mock.call([
+                "ol10_baseos_latest",
+                "ol10_appstream",
+                "ol10_addons",
+                "ol10_UEKR8"
+            ]),
+        ])
+        mock_yum_install.assert_called_once_with(
+            ['oraclelinux-release-el10'], mock_find_yum_repos.return_value)
+        mock_exec_cmd_chroot.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_find_yum_repos')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
+    @mock.patch.object(oracle.uuid, 'uuid4')
+    def test__get_oracle_repos_major_version_lt_8(
+            self, mock_uuid4, mock_yum_install, mock_find_yum_repos,
+            mock_exec_cmd_chroot):
+        result = self.oracle_morphing_tools._get_oracle_repos()
+
+        self.assertEqual(result, mock_find_yum_repos.return_value)
+
+        mock_find_yum_repos.assert_called_once_with([
+            "ol6_software_collections",
+            "ol6_addons",
+            "ol6_UEKR",
+            "ol6_latest"
+        ])
+        mock_yum_install.assert_not_called()
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call(
+                "curl -L http://public-yum.oracle.com/public-yum-ol6.repo "
+                "-o /etc/yum.repos.d/%s.repo" % mock_uuid4.return_value),
+            mock.call('sed -i "s/^enabled=1$/enabled=0/g" %s' % (
+                "/etc/yum.repos.d/%s.repo" % mock_uuid4.return_value))
+        ])

--- a/coriolis/tests/osmorphing/test_redhat.py
+++ b/coriolis/tests/osmorphing/test_redhat.py
@@ -1,0 +1,535 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+from unittest import mock
+
+import ddt
+
+from coriolis import exception
+from coriolis.osmorphing import base
+from coriolis.osmorphing import redhat
+from coriolis.tests import test_base
+
+
+@ddt.ddt
+class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseRedHatMorphingTools class."""
+
+    def setUp(self):
+        super(BaseRedHatMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': redhat.RED_HAT_DISTRO_IDENTIFIER,
+            'release_version': '6',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.package_names = ['package1', 'package2']
+        self.enable_repos = ['repo1', 'repo2']
+        self.event_manager = mock.MagicMock()
+        self.morphing_tools = redhat.BaseRedHatMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
+            self.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters,
+            mock.sentinel.operation_timeout)
+        self.morphing_tools._os_root_dir = '/root'
+
+    def test_check_os_supported(self):
+        result = redhat.BaseRedHatMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        self.detected_os_info['distribution_name'] = 'unsupported'
+
+        result = redhat.BaseRedHatMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_disable_predictable_nic_names(self, mock_exec_cmd_chroot):
+        self.morphing_tools.disable_predictable_nic_names()
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'grubby --update-kernel=ALL --args="net.ifnames=0 biosdevname=0"')
+
+    @mock.patch.object(
+        redhat.BaseRedHatMorphingTools, '_get_grub2_cfg_location'
+    )
+    def test_get_update_grub2_command(self, mock_get_grub2_cfg_location):
+        result = self.morphing_tools.get_update_grub2_command()
+
+        mock_get_grub2_cfg_location.assert_called_once()
+
+        self.assertEqual(
+            result,
+            'grub2-mkconfig -o %s' % mock_get_grub2_cfg_location.return_value
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub2_cfg_location_uefi(self, mock_test_path_chroot,
+                                          mock_exec_cmd_chroot):
+        mock_test_path_chroot.return_value = True
+
+        result = self.morphing_tools._get_grub2_cfg_location()
+
+        self.assertEqual(result, '/boot/efi/EFI/redhat/grub.cfg')
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("mount /boot || true"),
+            mock.call("mount /boot/efi || true")
+        ])
+        mock_test_path_chroot.assert_called_once_with(
+            '/boot/efi/EFI/redhat/grub.cfg')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub2_cfg_location_bios(self, mock_test_path_chroot,
+                                          mock_exec_cmd_chroot):
+        mock_test_path_chroot.side_effect = [False, True]
+
+        result = self.morphing_tools._get_grub2_cfg_location()
+
+        mock_test_path_chroot.assert_called_with('/boot/grub2/grub.cfg')
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("mount /boot || true"),
+            mock.call("mount /boot/efi || true")
+        ])
+
+        self.assertEqual(result, '/boot/grub2/grub.cfg')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub2_cfg_location_unknown(self, mock_test_path_chroot,
+                                             mock_exec_cmd_chroot):
+        mock_test_path_chroot.return_value = False
+
+        self.assertRaisesRegex(
+            Exception,
+            "could not determine grub location. boot partition not mounted?",
+            self.morphing_tools._get_grub2_cfg_location
+        )
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("mount /boot || true"),
+            mock.call("mount /boot/efi || true")
+        ])
+        mock_test_path_chroot.assert_has_calls([
+            mock.call('/boot/efi/EFI/redhat/grub.cfg'),
+            mock.call('/boot/grub2/grub.cfg')
+        ])
+
+    @ddt.data(
+        (
+            [("/path/to/ifcfg-file", {"HWADDR": "mac", "NAME": "test-name"})],
+            [],
+            [("test-name", "mac")]
+        ),
+        (
+            [("/path/to/ifcfg-file", {"NAME": "test-name"})],
+            ["mac"],
+            [("test-name", "mac")]
+        ),
+        (
+            [("/path/to/ifcfg-file", {"HWADDR": "mac"})],
+            ["mac"],
+            [("file", "mac")]
+        ),
+        (
+            [("/path/to/ifcfg-file", {"NAME": "test-name"})],
+            [],
+            []
+        )
+    )
+    @ddt.unpack
+    def test__get_net_ifaces_info(self, ifcfgs_ethernet, mac_addresses,
+                                  expected):
+        result = self.morphing_tools._get_net_ifaces_info(
+            ifcfgs_ethernet, mac_addresses)
+        self.assertEqual(result, expected)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    def test_add_net_udev_rules(self, mock_write_file_sudo, mock_test_path):
+        mock_test_path.return_value = False
+        net_ifaces_info = [
+            ("eth0", "AA:BB:CC:DD:EE:FF"),
+            ("eth1", "FF:EE:DD:CC:BB:AA")
+        ]
+        content = (
+            'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", '
+            'ATTR{address}=="aa:bb:cc:dd:ee:ff", NAME="eth0"\n'
+            'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", '
+            'ATTR{address}=="ff:ee:dd:cc:bb:aa", NAME="eth1"\n'
+        )
+
+        self.morphing_tools._add_net_udev_rules(net_ifaces_info)
+
+        mock_write_file_sudo.assert_called_once_with(
+            "etc/udev/rules.d/70-persistent-net.rules", content
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__has_systemd(self, mock_exec_cmd_chroot):
+        result = self.morphing_tools._has_systemd()
+
+        self.assertTrue(result)
+        mock_exec_cmd_chroot.assert_called_once_with("rpm -q systemd")
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__has_systemd_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = Exception()
+
+        result = self.morphing_tools._has_systemd()
+
+        self.assertFalse(result)
+
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_write_config_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_config_file')
+    def test__set_dhcp_net_config(self, mock_read_config_file,
+                                  mock_write_config_file):
+        ifcfgs_ethernet = [
+            (mock.sentinel.ifcfg_file,
+             {
+                 "BOOTPROTO": "none",
+                 "IPADDR": mock.sentinel.ip_address,
+                 "GATEWAY": mock.sentinel.gateway,
+                 "NETMASK": mock.sentinel.netmask,
+                 "NETWORK": mock.sentinel.network,
+             }),
+        ]
+        mock_read_config_file.return_value = {
+            "GATEWAY": mock.sentinel.gateway,
+        }
+
+        self.morphing_tools._set_dhcp_net_config(ifcfgs_ethernet)
+
+        mock_read_config_file.assert_called_once_with(
+            "etc/sysconfig/network", check_exists=True)
+        mock_write_config_file.assert_has_calls([
+            mock.call(mock.sentinel.ifcfg_file,
+                      {"BOOTPROTO": "dhcp", "UUID": mock.ANY}),
+            mock.call("etc/sysconfig/network",
+                      mock_read_config_file.return_value)
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_config_file')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_get_net_config_files')
+    def test__get_ifcfgs_by_type(self, mock_get_net_config_files,
+                                 mock_read_config_file):
+        mock_get_net_config_files.return_value = [mock.sentinel.ifcfg_file]
+        mock_read_config_file.side_effect = [{"TYPE": "Ethernet"}]
+
+        result = self.morphing_tools._get_ifcfgs_by_type("Ethernet")
+
+        mock_read_config_file.assert_called_once_with(mock.sentinel.ifcfg_file)
+        mock_get_net_config_files.assert_called_once()
+
+        self.assertEqual(
+            result, [(mock.sentinel.ifcfg_file, {"TYPE": "Ethernet"})])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    def test_write_nic_configs(
+            self, mock_test_path, mock_exec_cmd_chroot, mock_write_file_sudo):
+        nics_info = [{'name': 'eth0'}, {'name': 'eth1'}]
+        mock_test_path.return_value = True
+
+        self.morphing_tools._write_nic_configs(nics_info)
+
+        mock_write_file_sudo.assert_has_calls([
+            mock.call(
+                "etc/sysconfig/network-scripts/ifcfg-eth0",
+                redhat.IFCFG_TEMPLATE % {"device_name": "eth0"},
+            ),
+            mock.call(
+                "etc/sysconfig/network-scripts/ifcfg-eth1",
+                redhat.IFCFG_TEMPLATE % {"device_name": "eth1"},
+            )
+        ])
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("cp etc/sysconfig/network-scripts/ifcfg-eth0 "
+                      "etc/sysconfig/network-scripts/ifcfg-eth0.bak"),
+            mock.call("cp etc/sysconfig/network-scripts/ifcfg-eth1 "
+                      "etc/sysconfig/network-scripts/ifcfg-eth1.bak")
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    @mock.patch.object(redhat.utils, 'list_ssh_dir')
+    def test__comment_keys_from_ifcfg_files(
+            self, mock_list_ssh_dir, mock_exec_cmd):
+        keys = ['KEY1', 'KEY2']
+        interfaces = ['eth0', 'eth1']
+        mock_list_ssh_dir.return_value = [
+            'ifcfg-eth0', 'ifcfg-eth1', 'unknown-file', 'ifcfg-eth2']
+
+        self.morphing_tools._comment_keys_from_ifcfg_files(
+            keys, interfaces=interfaces)
+
+        mock_list_ssh_dir.assert_called_once_with(
+            mock.sentinel.conn, '/root/etc/sysconfig/network-scripts')
+        mock_exec_cmd.assert_has_calls([
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY1=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth0"
+            ),
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY2=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth0"
+            ),
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY1=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth1"
+            ),
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY2=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth1"
+            ),
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    @mock.patch.object(redhat.utils, 'list_ssh_dir')
+    def test__comment_keys_from_ifcfg_files_no_interfaces(
+            self, mock_list_ssh_dir, mock_exec_cmd):
+        keys = ['KEY1', 'KEY2']
+        mock_list_ssh_dir.return_value = ['ifcfg-eth0', 'ifcfg-eth1']
+
+        self.morphing_tools._comment_keys_from_ifcfg_files(keys)
+
+        mock_list_ssh_dir.assert_called_once_with(
+            mock.sentinel.conn, '/root/etc/sysconfig/network-scripts')
+
+        mock_exec_cmd.assert_has_calls([
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY1=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth0"
+            ),
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY2=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth0"
+            ),
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY1=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth1"
+            ),
+            mock.call(
+                "sudo sed -i.bak -E -e 's/^(KEY2=.*)$/# \\1/g' "
+                "/root/etc/sysconfig/network-scripts/ifcfg-eth1"
+            ),
+        ])
+
+    @mock.patch.object(
+        redhat.BaseRedHatMorphingTools, 'disable_predictable_nic_names'
+    )
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_write_nic_configs')
+    def test_set_net_config_dhcp(self, mock_write_nic_configs,
+                                 mock_disable_predictable_nic_names):
+        nics_info = [{
+            'mac_address': mock.sentinel.mac_address,
+        }]
+        dhcp = True
+
+        self.morphing_tools.set_net_config(nics_info, dhcp)
+
+        mock_disable_predictable_nic_names.assert_called_once()
+        mock_write_nic_configs.assert_called_once_with(nics_info)
+
+    @mock.patch.object(
+        redhat.BaseRedHatMorphingTools, 'disable_predictable_nic_names'
+    )
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_write_nic_configs')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_get_ifcfgs_by_type')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_get_net_ifaces_info')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_add_net_udev_rules')
+    def test_set_net_config_no_dhcp(
+            self, mock_add_net_udev_rules, mock_get_net_ifaces_info,
+            mock_get_ifcfgs_by_type, mock_write_nic_configs,
+            mock_disable_predictable_nic_names):
+        nics_info = [{
+            'mac_address': mock.sentinel.mac_address,
+        }]
+        dhcp = False
+
+        self.morphing_tools.set_net_config(nics_info, dhcp)
+
+        mock_disable_predictable_nic_names.assert_not_called()
+        mock_write_nic_configs.assert_not_called()
+        mock_get_ifcfgs_by_type.assert_called_once_with("Ethernet")
+        mock_get_net_ifaces_info.assert_called_once_with(
+            mock_get_ifcfgs_by_type.return_value, [mock.sentinel.mac_address])
+        mock_add_net_udev_rules.assert_called_once_with(
+            mock_get_net_ifaces_info.return_value)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__yum_install(self, mock_exec_cmd_chroot):
+        self.morphing_tools._yum_install(self.package_names, self.enable_repos)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "yum install package1 package2 -y "
+            "--enablerepo=repo1 --enablerepo=repo2"
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__yum_install_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        self.assertRaises(
+            exception.FailedPackageInstallationException,
+            self.morphing_tools._yum_install,
+            self.package_names, self.enable_repos
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__yum_uninstall(self, mock_exec_cmd_chroot):
+        self.morphing_tools._yum_uninstall(self.package_names)
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("yum remove package1 -y"),
+            mock.call("yum remove package2 -y")
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__yum_uninstall_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        self.assertRaises(
+            exception.FailedPackageUninstallationException,
+            self.morphing_tools._yum_uninstall, self.package_names
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    def test__yum_clean_all(self, mock_test_path, mock_exec_cmd_chroot):
+        mock_test_path.return_value = True
+
+        self.morphing_tools._yum_clean_all()
+
+        mock_test_path.assert_called_once_with("var/cache/yum")
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("yum clean all"),
+            mock.call("rm -rf /var/cache/yum")
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
+    def test__yum_clean_all_path_not_exists(self, mock_test_path,
+                                            mock_exec_cmd_chroot):
+        mock_test_path.return_value = False
+
+        self.morphing_tools._yum_clean_all()
+
+        mock_exec_cmd_chroot.assert_called_once_with("yum clean all")
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    def test__find_yum_repos_found(self, mock_read_file, mock_list_dir):
+        mock_list_dir.return_value = ['file1.repo', 'file2.repo']
+        mock_read_file.return_value = b'[repo1]\n[repo2]'
+        repos_to_enable = ['repo1']
+
+        result = self.morphing_tools._find_yum_repos(repos_to_enable)
+
+        mock_read_file.assert_has_calls([
+            mock.call('etc/yum.repos.d/file1.repo'),
+            mock.call('etc/yum.repos.d/file2.repo')
+        ])
+
+        self.assertEqual(result, ['repo1'])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    def test__find_yum_repos_not_found(self, mock_read_file, mock_list_dir):
+        mock_list_dir.return_value = ['file1.repo', 'file2.repo']
+        mock_read_file.return_value = b'[repo1]\n[repo2]'
+        repos_to_enable = ['repo3']
+
+        with self.assertLogs('coriolis.osmorphing.redhat', level=logging.WARN):
+            self.morphing_tools._find_yum_repos(repos_to_enable)
+
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_clean_all')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, 'pre_packages_install')
+    def test_pre_packages_install(self, mock_pre_packages_install,
+                                  mock_yum_clean_all, mock_yum_install):
+        self.morphing_tools.pre_packages_install(self.package_names)
+
+        mock_pre_packages_install.assert_called_once_with(self.package_names)
+        mock_yum_clean_all.assert_called_once()
+        mock_yum_install.assert_called_once_with(['grubby'])
+
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_get_repos_to_enable')
+    def test_install_packages(self, mock_get_repos_to_enable,
+                              mock_yum_install):
+        self.morphing_tools.install_packages(self.package_names)
+
+        mock_get_repos_to_enable.assert_called_once()
+        mock_yum_install.assert_called_once_with(
+            self.package_names, mock_get_repos_to_enable.return_value)
+
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_uninstall')
+    def test_uninstall_packages(self, mock_yum_uninstall):
+        self.morphing_tools.uninstall_packages(self.package_names)
+
+        mock_yum_uninstall.assert_called_once_with(self.package_names)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__run_dracut(self, mock_exec_cmd_chroot):
+        self.morphing_tools._run_dracut()
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "dracut --regenerate-all -f")
+
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_write_config_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_config_file')
+    def test__set_network_nozeroconf_config(
+            self, mock_read_config_file, mock_write_config_file):
+        self.morphing_tools._set_network_nozeroconf_config()
+
+        mock_read_config_file.assert_called_once_with(
+            "etc/sysconfig/network", check_exists=True)
+        mock_write_config_file.assert_called_once_with(
+            "etc/sysconfig/network", mock_read_config_file.return_value)
+
+    @mock.patch.object(
+        redhat.BaseRedHatMorphingTools, '_get_config_file_content'
+    )
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    def test__write_config_file(self, mock_write_file_sudo,
+                                mock_get_config_file_content):
+        self.morphing_tools._write_config_file(
+            mock.sentinel.chroot_path, mock.sentinel.config_data)
+
+        mock_get_config_file_content.assert_called_once_with(
+            mock.sentinel.config_data)
+        mock_write_file_sudo.assert_called_once_with(
+            mock.sentinel.chroot_path,
+            mock_get_config_file_content.return_value
+        )
+
+    def test__get_config_file_content(self):
+        config = {
+            'key1': 'value1',
+            'key2': 'value2'
+        }
+        result = self.morphing_tools._get_config_file_content(config)
+
+        self.assertEqual(result, 'key1="value1"\nkey2="value2"\n')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    def test__get_net_config_files(self, mock_list_dir):
+        mock_list_dir.return_value = ['ifcfg-eth0', 'ifcfg-lo', 'other-file']
+
+        result = self.morphing_tools._get_net_config_files()
+
+        expected_result = [
+            'etc/sysconfig/network-scripts/ifcfg-eth0',
+            'etc/sysconfig/network-scripts/ifcfg-lo'
+        ]
+
+        mock_list_dir.assert_called_once_with('etc/sysconfig/network-scripts')
+
+        self.assertEqual(result, expected_result)

--- a/coriolis/tests/osmorphing/test_rocky.py
+++ b/coriolis/tests/osmorphing/test_rocky.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+
+from coriolis.osmorphing import rocky
+from coriolis.tests import test_base
+
+
+class BaseRockyLinuxMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseRockyLinuxMorphingTools class."""
+
+    def test_check_os_supported(self):
+        detected_os_info = {
+            "distribution_name": rocky.ROCKY_LINUX_DISTRO_IDENTIFIER,
+            "release_version": "8"
+        }
+        result = rocky.BaseRockyLinuxMorphingTools.check_os_supported(
+            detected_os_info
+        )
+
+        self.assertTrue(result)
+
+    def test_check_os_not_supported(self):
+        detected_os_info = {
+            "distribution_name": "unsupported",
+        }
+        result = rocky.BaseRockyLinuxMorphingTools.check_os_supported(
+            detected_os_info
+        )
+
+        self.assertFalse(result)

--- a/coriolis/tests/osmorphing/test_suse.py
+++ b/coriolis/tests/osmorphing/test_suse.py
@@ -1,0 +1,332 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+from unittest import mock
+
+from coriolis import exception
+from coriolis.osmorphing import base
+from coriolis.osmorphing import suse
+from coriolis.tests import test_base
+
+
+class BaseSUSEMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseSUSEMorphingTools class."""
+
+    def setUp(self):
+        super(BaseSUSEMorphingToolsTestCase, self).setUp()
+        self.event_manager = mock.MagicMock()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            "distribution_name": suse.SLES_DISTRO_IDENTIFIER,
+            "release_version": "12",
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+            'suse_release_name': 'test release'
+        }
+        self.package_names = ['package1', 'package2']
+        self.morphing_tools = suse.BaseSUSEMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
+            self.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters,
+            mock.sentinel.operation_timeout)
+
+    def test_get_required_detected_os_info_fields(self):
+        result = (
+            suse.BaseSUSEMorphingTools.get_required_detected_os_info_fields()
+        )
+
+        base_fields = ['os_type', 'distribution_name', 'release_version',
+                       'friendly_release_name']
+        expected_result = base_fields + [suse.DETECTED_SUSE_RELEASE_FIELD_NAME]
+
+        self.assertEqual(expected_result, result)
+
+    def test_check_os_supported(self):
+        result = suse.BaseSUSEMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_supported_opensuse_tumbleweed(self):
+        self.detected_os_info[
+            'distribution_name'] = suse.OPENSUSE_DISTRO_IDENTIFIER
+        self.detected_os_info[
+            'release_version'] = suse.OPENSUSE_TUMBLEWEED_VERSION_IDENTIFIER
+
+        result = suse.BaseSUSEMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_supported_opensuse_unsupported_version(self):
+        self.detected_os_info[
+            'distribution_name'] = suse.OPENSUSE_DISTRO_IDENTIFIER
+        self.detected_os_info['release_version'] = 'unsupported'
+
+        result = suse.BaseSUSEMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    def test_check_os_not_supported(self):
+        self.detected_os_info['distribution_name'] = 'unsupported'
+        result = suse.BaseSUSEMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    @mock.patch.object(
+        suse.BaseSUSEMorphingTools, '_get_grub2_cfg_location'
+    )
+    def test_get_update_grub2_command(self, mock_get_grub2_cfg_location):
+        result = self.morphing_tools.get_update_grub2_command()
+
+        mock_get_grub2_cfg_location.assert_called_once_with()
+
+        self.assertEqual(
+            result,
+            "grub2-mkconfig -o %s" % mock_get_grub2_cfg_location.return_value
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub2_cfg_location_uefi(self, mock_test_path_chroot,
+                                          mock_exec_cmd_chroot):
+        mock_test_path_chroot.return_value = True
+
+        result = self.morphing_tools._get_grub2_cfg_location()
+
+        self.assertEqual(result, '/boot/efi/EFI/suse/grub.cfg')
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("mount /boot || true"),
+            mock.call("mount /boot/efi || true")
+        ])
+        mock_test_path_chroot.assert_called_once_with(
+            '/boot/efi/EFI/suse/grub.cfg')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub2_cfg_location_bios(self, mock_test_path_chroot,
+                                          mock_exec_cmd_chroot):
+        mock_test_path_chroot.side_effect = [False, True]
+
+        result = self.morphing_tools._get_grub2_cfg_location()
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("mount /boot || true"),
+            mock.call("mount /boot/efi || true")
+        ])
+        mock_test_path_chroot.assert_called_with(
+            '/boot/grub2/grub.cfg')
+
+        self.assertEqual(result, '/boot/grub2/grub.cfg')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
+    def test__get_grub2_cfg_location_not_found(self, mock_test_path_chroot,
+                                               mock_exec_cmd_chroot):
+        mock_test_path_chroot.return_value = False
+
+        self.assertRaisesRegex(
+            Exception,
+            "could not determine grub location. boot partition not mounted?",
+            self.morphing_tools._get_grub2_cfg_location
+        )
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("mount /boot || true"),
+            mock.call("mount /boot/efi || true")
+        ])
+        mock_test_path_chroot.assert_has_calls([
+            mock.call('/boot/efi/EFI/suse/grub.cfg'),
+            mock.call('/boot/grub2/grub.cfg')
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__run_dracut(self, mock_exec_cmd_chroot):
+        self.morphing_tools._run_dracut()
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "dracut --regenerate-all -f")
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__run_mkinitrd_success(self, mock_exec_cmd_chroot):
+        self.morphing_tools._run_mkinitrd()
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "mkinitrd")
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__run_mkinitrd_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = Exception()
+
+        with self.assertLogs('coriolis.osmorphing.suse', level=logging.WARN):
+            self.morphing_tools._run_mkinitrd()
+
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_run_mkinitrd')
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_run_dracut')
+    def test__rebuild_initrds(self, mock_run_dracut, mock_run_mkinitrd):
+        self.morphing_tools._detected_os_info['release_version'] = "11"
+
+        self.morphing_tools._rebuild_initrds()
+
+        mock_run_mkinitrd.assert_called_once()
+        mock_run_dracut.assert_not_called()
+
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_run_mkinitrd')
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_run_dracut')
+    def test__rebuild_initrds_old_version(self, mock_run_dracut,
+                                          mock_run_mkinitrd):
+        self.morphing_tools._rebuild_initrds()
+
+        mock_run_mkinitrd.assert_not_called()
+        mock_run_dracut.assert_called_once()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__has_systemd(self, mock_exec_cmd_chroot):
+        result = self.morphing_tools._has_systemd()
+
+        self.assertTrue(result)
+        mock_exec_cmd_chroot.assert_called_once_with("rpm -q systemd")
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__has_systemd_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = Exception()
+
+        result = self.morphing_tools._has_systemd()
+
+        self.assertFalse(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__enable_sles_module(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.return_value = b"module1\nmodule2\nmodule3"
+
+        self.morphing_tools._enable_sles_module("module2")
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("SUSEConnect --list-extensions"),
+            mock.call("cp /etc/zypp/zypp.conf /etc/zypp/zypp.conf.tmp"),
+            mock.call(
+                "sed -i -e 's/^gpgcheck.*//g' -e '$ a\\gpgcheck = off' "
+                "/etc/zypp/zypp.conf"
+            ),
+            mock.call(
+                'SUSEConnect -p %s' % 'module2'
+            ),
+            mock.call('mv -f /etc/zypp/zypp.conf.tmp /etc/zypp/zypp.conf'),
+            mock.call('zypper --non-interactive --no-gpg-checks refresh')
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__enable_sles_module_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = [
+            b"module output", None, None, Exception()]
+
+        self.assertRaises(exception.CoriolisException,
+                          self.morphing_tools._enable_sles_module,
+                          mock.sentinel.module)
+
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_add_repo')
+    def test_add_cloud_tools_repo(self, mock_add_repo):
+        self.morphing_tools._add_cloud_tools_repo()
+
+        expected_repo = suse.CLOUD_TOOLS_REPO_URI_FORMAT % (
+            'test_release', '_12')
+        mock_add_repo.assert_called_once_with(expected_repo, 'Cloud-Tools')
+
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_add_repo')
+    def test_add_cloud_tools_repo_with_tumbleweed_version(self, mock_add_repo):
+        self.morphing_tools._version = (
+            suse.OPENSUSE_TUMBLEWEED_VERSION_IDENTIFIER)
+
+        self.morphing_tools._add_cloud_tools_repo()
+
+        expected_repo = suse.CLOUD_TOOLS_REPO_URI_FORMAT % ('test_release', '')
+        mock_add_repo.assert_called_once_with(expected_repo, 'Cloud-Tools')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__get_repos(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.return_value = (
+            b"repo1 http://repo1.com\nrepo2 http://repo2.com")
+
+        result = self.morphing_tools._get_repos()
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "zypper repos -u | awk -F '|' '/^\\s[0-9]+/ {print $2 $7}'")
+
+        expected_result = {
+            'repo1': 'http://repo1.com', 'repo2': 'http://repo2.com'}
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_get_repos')
+    def test__add_repo_existing_same_uri(self, mock_get_repos,
+                                         mock_exec_cmd_chroot):
+        mock_get_repos.return_value = {'alias': 'http://repo.com'}
+
+        with self.assertLogs('coriolis.osmorphing.suse', level=logging.DEBUG):
+            self.morphing_tools._add_repo('http://repo.com', 'alias')
+
+        mock_get_repos.assert_called_once()
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("zypper --non-interactive modifyrepo -e alias"),
+            mock.call("zypper --non-interactive --no-gpg-checks refresh")
+        ])
+
+    @mock.patch.object(suse.uuid, 'uuid4')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_get_repos')
+    def test__add_repo_new(self, mock_get_repos, mock_exec_cmd_chroot,
+                           mock_uuid4):
+        mock_get_repos.return_value = {'alias': 'http://oldrepo.com'}
+
+        self.morphing_tools._add_repo('http://newrepo.com', 'alias')
+
+        mock_get_repos.assert_called_once()
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call(
+                "zypper --non-interactive addrepo -f http://newrepo.com alias"
+                "%s" % mock_uuid4.return_value),
+            mock.call("zypper --non-interactive --no-gpg-checks refresh")
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_get_repos')
+    def test__add_repo_with_exception(self, mock_get_repos,
+                                      mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = Exception()
+
+        self.assertRaises(exception.CoriolisException,
+                          self.morphing_tools._add_repo,
+                          'http://repo.com', 'alias')
+
+        mock_get_repos.assert_called_once()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_install_packages(self, mock_exec_cmd_chroot):
+        self.morphing_tools.install_packages(self.package_names)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'zypper --non-interactive install package1 package2')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_install_packages_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        self.assertRaises(exception.FailedPackageInstallationException,
+                          self.morphing_tools.install_packages,
+                          self.package_names)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_uninstall_packages(self, mock_exec_cmd_chroot):
+        self.morphing_tools.uninstall_packages(self.package_names)
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'zypper --non-interactive remove package1 package2')
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_uninstall_packages_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        with self.assertLogs('coriolis.osmorphing.suse', level=logging.WARN):
+            self.morphing_tools.uninstall_packages(self.package_names)

--- a/coriolis/tests/osmorphing/test_ubuntu.py
+++ b/coriolis/tests/osmorphing/test_ubuntu.py
@@ -1,0 +1,167 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import logging
+from unittest import mock
+
+from coriolis.osmorphing import base
+from coriolis.osmorphing import ubuntu
+from coriolis.tests import test_base
+
+
+class BaseUbuntuMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseUbuntuMophingTools class."""
+
+    def setUp(self):
+        super(BaseUbuntuMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': 'Ubuntu',
+            'release_version': '22.04',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.event_manager = mock.MagicMock()
+        self.os_root_dir = '/root'
+        self.morphing_tools = ubuntu.BaseUbuntuMorphingTools(
+            mock.sentinel.conn, self.os_root_dir,
+            mock.sentinel.os_root_dev, mock.sentinel.hypervisor,
+            self.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters,
+            mock.sentinel.operation_timeout)
+
+    def test_check_os_supported_not_supported(self):
+        self.detected_os_info['distribution_name'] = 'unsupported'
+
+        result = ubuntu.BaseUbuntuMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    def test_check_os_supported_lts_release(self):
+        self.detected_os_info['release_version'] = '20.04'
+
+        result = ubuntu.BaseUbuntuMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_supported_non_lts_release(self):
+        result = ubuntu.BaseUbuntuMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    def test__set_netplan_ethernet_configs(
+            self, mock_list_dir, mock_read_file, mock_write_file_sudo,
+            mock_exec_cmd):
+        mock_list_dir.return_value = ['file1', 'file2.yaml']
+        mock_read_file.return_value = (
+            b'network: {version: 2, ethernets: {eth0: {dhcp4: true}}}')
+        nics_info = [
+            {'name': 'eth0', 'mac_address': '00:00:00:00:00:00'},
+            {'name': 'eth1', 'mac_address': '00:00:00:00:00:01'}]
+        config_data = {
+            'network': {
+                'ethernets': {
+                    'test0': {
+                        'dhcp4': True,
+                        'dhcp6': True
+                    }
+                },
+                'version': 2
+            }
+        }
+
+        self.morphing_tools._set_netplan_ethernet_configs(
+            nics_info, dhcp=True, iface_name_prefix='test')
+
+        mock_exec_cmd.assert_called_once_with(
+            "sudo cp '%s/etc/netplan/file2.yaml' "
+            "'%s/etc/netplan/file2.yaml.bak'" % (
+                self.os_root_dir, self.os_root_dir))
+        mock_read_file.assert_called_once_with('etc/netplan/file2.yaml')
+        mock_write_file_sudo.assert_called_once_with(
+            'etc/netplan/file2.yaml', ubuntu.yaml.dump(config_data))
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    def test__set_netplan_ethernet_configs_no_network_data(
+            self, mock_list_dir, mock_read_file, mock_write_file_sudo,
+            mock_exec_cmd):
+        mock_list_dir.return_value = ['file1.yaml']
+        mock_read_file.return_value = b'{}'
+
+        with self.assertLogs('coriolis.osmorphing.ubuntu',
+                             level=logging.DEBUG):
+            self.morphing_tools._set_netplan_ethernet_configs(
+                mock.sentinel.nics_info)
+
+        mock_read_file.assert_called_once_with('etc/netplan/file1.yaml')
+        mock_exec_cmd.assert_called_once_with(
+            "sudo cp '%s/etc/netplan/file1.yaml' "
+            "'%s/etc/netplan/file1.yaml.bak'" % (
+                self.os_root_dir, self.os_root_dir))
+        mock_write_file_sudo.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    def test__set_netplan_ethernet_configs_incompatible_version(
+            self, mock_list_dir, mock_read_file, mock_write_file_sudo,
+            mock_exec_cmd):
+        mock_list_dir.return_value = ['file1.yaml']
+        mock_read_file.return_value = b'network: {version: 4}'
+
+        with self.assertLogs('coriolis.osmorphing.ubuntu',
+                             level=logging.DEBUG):
+            self.morphing_tools._set_netplan_ethernet_configs(
+                mock.sentinel.nics_info)
+
+        mock_read_file.assert_called_once_with('etc/netplan/file1.yaml')
+        mock_exec_cmd.assert_called_once_with(
+            "sudo cp '%s/etc/netplan/file1.yaml' "
+            "'%s/etc/netplan/file1.yaml.bak'" % (
+                self.os_root_dir, self.os_root_dir))
+        mock_write_file_sudo.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
+    def test__set_netplan_ethernet_configs_no_ethernet_configs(
+            self, mock_list_dir, mock_read_file, mock_write_file_sudo,
+            mock_exec_cmd):
+        mock_list_dir.return_value = ['file1.yaml']
+        mock_read_file.return_value = (
+            b'network: {version: 2, ethernets: {eth0: {dhcp4: true}}}')
+
+        nics_info = [{'name': 'eth0', 'mac_address': '00:00:00:00:00:00'}]
+
+        with self.assertLogs('coriolis.osmorphing.ubuntu',
+                             level=logging.DEBUG):
+            self.morphing_tools._set_netplan_ethernet_configs(nics_info)
+
+        config_data = {
+            'network': {
+                'ethernets': {
+                    'eth0': {
+                        'dhcp4': True,
+                    }
+                },
+                'version': 2
+            }
+        }
+        mock_read_file.assert_called_once_with('etc/netplan/file1.yaml')
+        mock_exec_cmd.assert_called_once_with(
+            "sudo cp '%s/etc/netplan/file1.yaml' "
+            "'%s/etc/netplan/file1.yaml.bak'" % (
+                self.os_root_dir, self.os_root_dir))
+        mock_write_file_sudo.assert_called_once_with(
+            'etc/netplan/file1.yaml', ubuntu.yaml.dump(config_data))

--- a/coriolis/tests/osmorphing/test_windows.py
+++ b/coriolis/tests/osmorphing/test_windows.py
@@ -1,0 +1,857 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+import base64
+import json
+import logging
+from unittest import mock
+
+from coriolis import exception
+from coriolis.osmorphing import windows
+from coriolis.tests import test_base
+
+WIN_VERSION_PS_OUTPUT = """
+CurrentVersion            : 6.3
+CurrentMajorVersionNumber : 10
+CurrentMinorVersionNumber : 0
+CurrentBuildNumber        : 20348
+InstallationType          : Server
+ProductName               : Windows Server 2022 Datacenter Evaluation
+EditionID                 : ServerDatacenterEval
+"""
+
+
+class CoriolisTestException(Exception):
+    pass
+
+
+class BaseWindowsMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
+    """Test suite for the BaseWindowsMorphingTools class."""
+
+    def setUp(self):
+        super(BaseWindowsMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'windows',
+            'distribution_name': 'Windows',
+            'release_version': '10',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+            'version_number': mock.sentinel.version_number,
+            'edition_id': mock.sentinel.edition_id,
+            'installation_type': mock.sentinel.installation_type,
+            'product_name': mock.sentinel.product_name,
+        }
+        self.conn = mock.MagicMock()
+        self.event_manager = mock.MagicMock()
+        self.os_root_dir = 'C:\\'
+        self.morphing_tools = windows.BaseWindowsMorphingTools(
+            self.conn, self.os_root_dir,
+            mock.sentinel.os_root_dev, mock.sentinel.hypervisor,
+            self.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters,
+            mock.sentinel.operation_timeout)
+
+    def test_get_required_detected_os_info_fields(self):
+        result = windows.BaseWindowsMorphingTools.\
+            get_required_detected_os_info_fields()
+
+        expected_fields = (
+            windows.base.REQUIRED_DETECTED_OS_FIELDS +
+            windows.REQUIRED_DETECTED_WINDOWS_OS_FIELDS
+        )
+
+        self.assertEqual(result, expected_fields)
+
+    def test_check_os_supported(self):
+        result = windows.BaseWindowsMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertTrue(result)
+
+    def test_check_os_supported_not_supported(self):
+        self.detected_os_info['os_type'] = 'unsupported'
+
+        result = windows.BaseWindowsMorphingTools.check_os_supported(
+            self.detected_os_info)
+
+        self.assertFalse(result)
+
+    def test__get_worker_os_drive_path(self):
+        result = self.morphing_tools._get_worker_os_drive_path()
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            "(Get-WmiObject Win32_OperatingSystem).SystemDrive")
+
+        self.assertEqual(result, self.conn.exec_ps_command.return_value)
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_get_worker_os_drive_path'
+    )
+    def test__get_dism_path(self, mock_get_worker_os_drive_path):
+        mock_get_worker_os_drive_path.return_value = 'C:'
+
+        result = self.morphing_tools._get_dism_path()
+
+        mock_get_worker_os_drive_path.assert_called_once_with()
+
+        self.assertEqual(
+            result,
+            "C:\\Windows\\System32\\dism.exe"
+        )
+
+    def test__get_sid(self):
+        result = self.morphing_tools._get_sid()
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            "(New-Object System.Security.Principal.NTAccount($ENV:USERNAME))."
+            "Translate([System.Security.Principal.SecurityIdentifier]).Value"
+        )
+
+        self.assertEqual(result, self.conn.exec_ps_command.return_value)
+
+    def test__grant_permissions(self):
+        self.morphing_tools._grant_permissions(
+            mock.sentinel.path, mock.sentinel.user, perm="(OI)(CI)F")
+
+        self.conn.exec_command.assert_called_once_with(
+            'icacls.exe',
+            [mock.sentinel.path, '/grant', 'sentinel.user:(OI)(CI)F'])
+
+    def test__revoke_permissions(self):
+        self.morphing_tools._revoke_permissions(
+            mock.sentinel.path, mock.sentinel.user)
+
+        self.conn.exec_command.assert_called_once_with(
+            'icacls.exe',
+            [mock.sentinel.path, '/remove', mock.sentinel.user])
+
+    def test__load_registry_hive(self):
+        self.morphing_tools._load_registry_hive(
+            mock.sentinel.subkey, mock.sentinel.path)
+
+        self.conn.exec_command.assert_called_once_with(
+            'reg.exe',
+            ['load', mock.sentinel.subkey, mock.sentinel.path])
+
+    def test__unload_registry_hive(self):
+        self.morphing_tools._unload_registry_hive(mock.sentinel.subkey)
+
+        self.conn.exec_command.assert_called_once_with(
+            'reg.exe',
+            ['unload', mock.sentinel.subkey])
+
+    def test__get_ps_fl_value(self):
+        result = self.morphing_tools._get_ps_fl_value(
+            WIN_VERSION_PS_OUTPUT, 'InstallationType')
+
+        self.assertEqual(result, 'Server')
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_get_worker_os_drive_path'
+    )
+    def test__add_dism_driver(self, mock_get_worker_os_drive_path):
+        mock_get_worker_os_drive_path.return_value = "C:"
+        result = self.morphing_tools._add_dism_driver(
+            mock.sentinel.driver_path)
+
+        self.assertEqual(result, self.conn.exec_command.return_value)
+        self.conn.exec_command.assert_called_once_with(
+            "C:\\Windows\\System32\\dism.exe",
+            ['/add-driver', '/image:%s' % self.os_root_dir,
+             '/driver:"%s"' % mock.sentinel.driver_path,
+             '/recurse', '/forceunsigned'])
+
+        mock_get_worker_os_drive_path.assert_called_once_with()
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_get_worker_os_drive_path'
+    )
+    def test__add_dism_driver_exception(self, mock_get_worker_os_drive_path):
+        mock_get_worker_os_drive_path.return_value = "C:"
+        self.conn.test_path.return_value = True
+        self.conn.exec_command.side_effect = CoriolisTestException
+
+        with self.assertLogs('coriolis.osmorphing.windows',
+                             level=logging.ERROR):
+            self.assertRaises(CoriolisTestException,
+                              self.morphing_tools._add_dism_driver,
+                              mock.sentinel.driver_path)
+        mock_get_worker_os_drive_path.assert_called()
+        self.conn.test_path.assert_called_once_with(
+            "C:\\Windows\\Logs\\DISM\\dism.log")
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_get_worker_os_drive_path'
+    )
+    def test__add_dism_driver_not_found(self, mock_get_worker_os_drive_path):
+        self.conn.test_path.return_value = False
+        self.conn.exec_command.side_effect = CoriolisTestException
+
+        with self.assertLogs('coriolis.osmorphing.windows',
+                             level=logging.WARN):
+            self.assertRaises(CoriolisTestException,
+                              self.morphing_tools._add_dism_driver,
+                              mock.sentinel.driver_path)
+        mock_get_worker_os_drive_path.assert_called()
+
+    def test__mount_disk_image(self):
+        result = self.morphing_tools._mount_disk_image(
+            mock.sentinel.path)
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            "(Mount-DiskImage '%s' -PassThru | Get-Volume).DriveLetter" %
+            mock.sentinel.path)
+
+        self.assertEqual(result, self.conn.exec_ps_command.return_value)
+
+    def test__dismount_disk_image(self):
+        self.morphing_tools._dismount_disk_image(mock.sentinel.path)
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            "Dismount-DiskImage '%s'" % mock.sentinel.path, ignore_stdout=True)
+
+    def test__expand_archive(self):
+        self.conn.test_path.return_value = True
+        destination = 'C:\\Windows\\destination'
+
+        with self.assertLogs('coriolis.osmorphing.windows',
+                             level=logging.WARN):
+            self.morphing_tools._expand_archive(
+                mock.sentinel.archive_path, destination)
+
+        self.conn.exec_ps_command.assert_called_once()
+
+    def test__expand_archive_remove_destination(self):
+        self.conn.test_path.return_value = True
+
+        destination = 'C:\\test\\destination'
+
+        self.morphing_tools._expand_archive(
+            mock.sentinel.archive_path, destination)
+
+        self.conn.exec_ps_command.assert_has_calls([
+            mock.call("rm -recurse -force %s" % destination),
+            mock.call(
+                "if(([System.Management.Automation.PSTypeName]"
+                "'System.IO.Compression.ZipFile').Type -or "
+                "[System.Reflection.Assembly]::LoadWithPartialName("
+                "'System.IO.Compression.FileSystem')) {"
+                "[System.IO.Compression.ZipFile]::ExtractToDirectory("
+                "'%(path)s', '%(destination)s')} else {mkdir -Force "
+                "'%(destination)s'; $shell = New-Object -ComObject "
+                "Shell.Application;$shell.Namespace("
+                "'%(destination)s').copyhere(($shell.NameSpace("
+                "'%(path)s')).items())}" %
+                {"path": mock.sentinel.archive_path,
+                 "destination": destination},
+                ignore_stdout=True)
+        ])
+
+    def test__set_service_start_mode(self):
+        self.morphing_tools._set_service_start_mode(
+            mock.sentinel.key_name, mock.sentinel.service_name,
+            mock.sentinel.start_mode)
+
+        registry_path = windows.SERVICE_PATH_FORMAT % (
+            mock.sentinel.key_name, mock.sentinel.service_name)
+        expected_command = (
+            "Set-ItemProperty -Path '%s' -Name 'Start' -Value %s" %
+            (registry_path, mock.sentinel.start_mode))
+
+        self.conn.exec_ps_command.assert_called_once_with(expected_command)
+
+    def test__create_service(self):
+        service_account = 'LocalSystem'
+        depends_on = [mock.sentinel.depends_on]
+
+        self.morphing_tools._create_service(
+            mock.sentinel.key_name, mock.sentinel.service_name,
+            mock.sentinel.image_path, mock.sentinel.display_name,
+            mock.sentinel.description, windows.SERVICE_START_AUTO,
+            service_account, depends_on)
+
+        registry_path = windows.SERVICE_PATH_FORMAT % (
+            mock.sentinel.key_name, mock.sentinel.service_name)
+        depends_on_ps = "@('%s')" % mock.sentinel.depends_on
+
+        expected_commands = (
+            "$ErrorActionPreference = 'Stop';"
+            "New-Item -Path '%(path)s' -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'ImagePath' -Value "
+            "'%(image_path)s' -Type ExpandString -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'DisplayName' -Value "
+            "'%(display_name)s' -Type String -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'Description' -Value "
+            "'%(description)s' -Type String -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'DependOnService' -Value "
+            "%(depends_on)s -Type MultiString -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'ObjectName' -Value "
+            "'%(service_account)s' -Type String -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'Start' -Value "
+            "%(start_mode)s -Type DWord -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'Type' -Value "
+            "16 -Type DWord -Force;"
+            "New-ItemProperty -Path '%(path)s' -Name 'ErrorControl' -Value "
+            "0 -Type DWord -Force" %
+            {"path": registry_path, "image_path": mock.sentinel.image_path,
+             "display_name": mock.sentinel.display_name,
+             "description": mock.sentinel.description,
+             "depends_on": depends_on_ps, "service_account": service_account,
+             "start_mode": windows.SERVICE_START_AUTO}
+        )
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            expected_commands, ignore_stdout=True)
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    def test_run_user_script(self, mock_write_winrm_file):
+        user_script = 'echo "Hello, World!"'
+        script_path = "$env:TMP\\coriolis_user_script.ps1"
+
+        self.morphing_tools.run_user_script(user_script)
+
+        mock_write_winrm_file.assert_called_once_with(
+            self.conn, script_path, user_script)
+        self.conn.exec_ps_command.assert_called_once_with(
+            ('$ErrorActionPreference = "Stop"; powershell.exe '
+             '-NonInteractive -ExecutionPolicy RemoteSigned '
+             '-File "%(script)s" "%(os_root_dir)s"') % {
+                 "script": script_path,
+                 "os_root_dir": self.os_root_dir,
+            }
+        )
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    def test_run_user_script_empty_script(self, mock_write_winrm_file):
+        result = self.morphing_tools.run_user_script("")
+
+        self.assertIsNone(result)
+        mock_write_winrm_file.assert_not_called()
+        self.conn.exec_ps_command.assert_not_called()
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    def test_run_user_script_raises_exception_on_write_winrm_file(
+            self, mock_write_winrm_file):
+        user_script = 'echo "Hello, World!"'
+        mock_write_winrm_file.side_effect = exception.CoriolisException
+
+        self.assertRaises(
+            exception.CoriolisException,
+            self.morphing_tools.run_user_script, user_script)
+
+        self.conn.exec_ps_command.assert_not_called()
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    def test_run_user_script_raises_exception_on_exec_ps_command(
+            self, mock_write_winrm_file):
+        user_script = 'echo "Hello, World!"'
+        script_path = "$env:TMP\\coriolis_user_script.ps1"
+
+        self.conn.exec_ps_command.side_effect = exception.CoriolisException
+
+        self.assertRaises(
+            exception.CoriolisException,
+            self.morphing_tools.run_user_script, user_script)
+
+        mock_write_winrm_file.assert_called_once_with(
+            self.conn, script_path, user_script)
+
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_load_registry_hive')
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_check_cloudbase_init_exists'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_set_service_start_mode'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_unload_registry_hive'
+    )
+    @mock.patch.object(windows.uuid, 'uuid4')
+    def test__disable_cloudbase_init(
+            self, mock_uuid4, mock_unload_registry_hive,
+            mock_set_service_start_mode, mock_check_cloudbase_init_exists,
+            mock_load_registry_hive):
+        self.morphing_tools._disable_cloudbase_init()
+
+        mock_check_cloudbase_init_exists.return_value = True
+
+        mock_load_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value,
+            "%sWindows\\System32\\config\\SYSTEM" % self.os_root_dir)
+
+        mock_set_service_start_mode.assert_called_once_with(
+            str(mock_uuid4.return_value), windows.CLOUDBASEINIT_SERVICE_NAME,
+            windows.SERVICE_START_DISABLED)
+        mock_unload_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value)
+
+    def test__check_cloudbase_init_exists(self):
+        self.conn.exec_ps_command.return_value = "True"
+        result = self.morphing_tools._check_cloudbase_init_exists(
+            mock.sentinel.key_name)
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            "Test-Path %s" % (windows.SERVICE_PATH_FORMAT % (
+                mock.sentinel.key_name, windows.CLOUDBASEINIT_SERVICE_NAME)))
+
+        self.assertTrue(result)
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_set_service_start_mode'
+    )
+    def test__setup_existing_cbslinit_service(
+            self, mock_set_service_start_mode):
+        self.morphing_tools._setup_existing_cbslinit_service(
+            mock.sentinel.key_name, mock.sentinel.image_path)
+
+        reg_service_path = windows.SERVICE_PATH_FORMAT % (
+            mock.sentinel.key_name, windows.CLOUDBASEINIT_SERVICE_NAME)
+
+        self.conn.exec_ps_command.assert_has_calls([
+            mock.call(
+                "Set-ItemProperty -Path '%s' -Name 'ImagePath' -Value '%s' "
+                "-Force" % (reg_service_path, mock.sentinel.image_path),
+            ),
+            mock.call(
+                "Set-ItemProperty -Path '%s' -Name 'ObjectName' "
+                "-Value 'LocalSystem' -Force" % reg_service_path
+            ),
+        ])
+
+        mock_set_service_start_mode.assert_called_once_with(
+            mock.sentinel.key_name, windows.CLOUDBASEINIT_SERVICE_NAME,
+            windows.SERVICE_START_AUTO)
+
+    def test__get_cbslinit_base_dir(self):
+        result = self.morphing_tools._get_cbslinit_base_dir()
+
+        self.assertEqual(result, "%sCloudbase-Init" % self.os_root_dir)
+
+    def test__get_cbslinit_scripts_dir(self):
+        result = self.morphing_tools._get_cbslinit_scripts_dir('C:')
+
+        self.assertEqual(result, "C:\\LocalScripts")
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    def test__write_local_script(self, mock_write_winrm_file):
+        script_path = "/script/path/script.sh"
+
+        with mock.patch('builtins.open', mock.mock_open()) as mock_open:
+            self.morphing_tools._write_local_script(
+                'C:', script_path, priority=50)
+            mock_open.assert_called_once_with(script_path, 'r')
+            mock_write_winrm_file.assert_called_once_with(
+                self.conn,
+                'C:\\LocalScripts\\50-script.sh',
+                '')
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_write_local_script')
+    def test__write_cloudbase_init_conf(
+            self, mock_write_local_script, mock_write_winrm_file):
+        local_base_dir = "C:\\LocalBaseDir"
+        mocked_full_path = windows.os.path.join(
+            windows.utils.get_resources_bin_dir(), 'bring-disks-online.ps1')
+
+        self.morphing_tools._write_cloudbase_init_conf(
+            'C:\\Cloudbase-Init', local_base_dir, com_port='COM1')
+
+        self.conn.exec_ps_command.assert_has_calls([
+            mock.call(
+                "mkdir 'C:\\Cloudbase-Init\\conf' -Force",
+                ignore_stdout=True),
+            mock.call(
+                "mkdir 'C:\\Cloudbase-Init\\LocalScripts' -Force",
+                ignore_stdout=True),
+        ])
+
+        conf_file_path = (
+            "C:\\Cloudbase-Init\\conf\\cloudbase-init.conf")
+        conf_content = (
+            "[DEFAULT]\r\n"
+            "username = Admin\r\n"
+            "groups = Administrators\r\n"
+            "verbose = true\r\n"
+            "bsdtar_path = %(bin_path)s\\bsdtar.exe\r\n"
+            "mtools_path = %(bin_path)s\r\n"
+            "logdir = %(log_path)s\r\n"
+            "local_scripts_path = %(scripts_path)s\r\n"
+            "stop_service_on_exit = false\r\n"
+            "logfile = cloudbase-init.log\r\n"
+            "default_log_levels = \r\n"
+            "comtypes=INFO,suds=INFO,iso8601=WARN,requests=WARN\r\n"
+            "allow_reboot = false\r\n"
+            "plugins = %(plugins)s\r\n"
+            "debug = true\r\n"
+            "san_policy = OnlineAll\r\n"
+            "metadata_services = %(metadata_services)s\r\n"
+            "logging_serial_port_settings = %(com_port)s,9600,N,8\r\n" %
+            {"bin_path": "%s\\Bin" % local_base_dir,
+             "log_path": "%s\\Log" % local_base_dir,
+             "scripts_path": "%s\\LocalScripts" % local_base_dir,
+             "com_port": 'COM1',
+             "metadata_services": ",".join(
+                 windows.CLOUDBASE_INIT_DEFAULT_METADATA_SVCS),
+             "plugins": ",".join(windows.CLOUDBASE_INIT_DEFAULT_PLUGINS)})
+
+        mock_write_winrm_file.assert_called_once_with(
+            self.conn, conf_file_path, conf_content)
+
+        mock_write_local_script.assert_called_once_with(
+            'C:\\Cloudbase-Init', mocked_full_path, priority=99)
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_write_local_script')
+    def test__write_cloudbase_init_conf_with_exception(
+            self, mock_write_local_script, mock_write_winrm_file):
+        plugins = "invalid plugins"
+
+        self.assertRaises(
+            exception.CoriolisException,
+            self.morphing_tools._write_cloudbase_init_conf,
+            mock.sentinel.cloudbaseinit_base_dir, mock.sentinel.local_base_dir,
+            com_port='COM1', plugins=plugins)
+
+        self.conn.exec_ps_command.assert_not_called()
+        mock_write_winrm_file.assert_not_called()
+        mock_write_local_script.assert_not_called()
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_unload_registry_hive'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_write_cloudbase_init_conf'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_check_cloudbase_init_exists'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_setup_existing_cbslinit_service'
+    )
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_create_service')
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_expand_archive')
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_load_registry_hive')
+    @mock.patch.object(windows.uuid, 'uuid4')
+    def test__install_cloudbase_init(
+            self, mock_uuid4, mock_load_registry_hive,
+            mock_expand_archive, mock_create_service,
+            mock_setup_existing_cbslinit_service,
+            mock_check_cloudbase_init_exists, mock_write_cloudbase_init_conf,
+            mock_unload_registry_hive):
+        cloudbaseinit_zip_path = 'c:\\cloudbaseinit.zip'
+        cloudbaseinit_base_dir = "C:\\Cloudbase-Init"
+        local_base_dir = "C%s" % cloudbaseinit_base_dir[1:]
+
+        mock_check_cloudbase_init_exists.return_value = False
+
+        result = self.morphing_tools._install_cloudbase_init(
+            mock.sentinel.download_url, com_port='COM1')
+
+        mock_load_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value,
+            "%sWindows\\System32\\config\\SYSTEM" % self.os_root_dir)
+
+        mock_expand_archive.assert_called_once_with(
+            cloudbaseinit_zip_path, cloudbaseinit_base_dir)
+
+        self.conn.exec_ps_command.assert_called_once_with(
+            "mkdir '%s' -Force" %
+            ("%s\\Log" % cloudbaseinit_base_dir),
+            ignore_stdout=True)
+
+        mock_write_cloudbase_init_conf.assert_called_once_with(
+            cloudbaseinit_base_dir, local_base_dir,
+            metadata_services=None, plugins=None, com_port='COM1')
+        mock_check_cloudbase_init_exists.assert_called_once_with(
+            str(mock_uuid4.return_value))
+
+        expected_image_path = (
+            '"%(path)s\\Bin\\OpenStackService.exe" cloudbase-init '
+            '"%(path)s\\Python\\Python.exe" '
+            '"%(path)s\\Python\\Scripts\\cloudbase-init.exe" '
+            '--config-file "%(path)s\\conf\\cloudbase-init.conf"' % {
+                'path': local_base_dir})
+
+        mock_setup_existing_cbslinit_service.assert_not_called()
+        mock_create_service.assert_called_once_with(
+            key_name=str(mock_uuid4.return_value),
+            service_name=windows.CLOUDBASEINIT_SERVICE_NAME,
+            image_path=expected_image_path,
+            display_name='Cloud Initialization Service',
+            description='Service wrapper for cloudbase-init',
+        )
+
+        mock_unload_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value)
+
+        self.assertEqual(result, cloudbaseinit_base_dir)
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_unload_registry_hive'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_check_cloudbase_init_exists'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_setup_existing_cbslinit_service'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_write_cloudbase_init_conf'
+    )
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_create_service')
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_expand_archive')
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_load_registry_hive')
+    @mock.patch.object(windows.uuid, 'uuid4')
+    def test_install_cloudbase_init_existing_service(
+            self, mock_uuid4, mock_load_registry_hive, mock_expand_archive,
+            mock_create_service, mock_write_cloudbase_init_conf,
+            mock_setup_existing_cbslinit_service,
+            mock_check_cloudbase_init_exists, mock_unload_registry_hive):
+        cloudbaseinit_zip_path = 'c:\\cloudbaseinit.zip'
+        cloudbaseinit_base_dir = "C:\\Cloudbase-Init"
+        local_base_dir = "C%s" % cloudbaseinit_base_dir[1:]
+        mock_check_cloudbase_init_exists.return_value = True
+
+        self.morphing_tools._install_cloudbase_init(mock.sentinel.download_url,
+                                                    com_port='COM1')
+
+        expected_image_path = (
+            '"%(path)s\\Bin\\OpenStackService.exe" cloudbase-init '
+            '"%(path)s\\Python\\Python.exe" '
+            '"%(path)s\\Python\\Scripts\\cloudbase-init.exe" '
+            '--config-file "%(path)s\\conf\\cloudbase-init.conf"' % {
+                'path': local_base_dir})
+
+        mock_load_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value,
+            "%sWindows\\System32\\config\\SYSTEM" % self.os_root_dir)
+        mock_expand_archive.assert_called_once_with(
+            cloudbaseinit_zip_path, cloudbaseinit_base_dir)
+        self.conn.exec_ps_command.assert_called_once_with(
+            "mkdir '%s' -Force" %
+            ("%s\\Log" % cloudbaseinit_base_dir),
+            ignore_stdout=True)
+
+        mock_write_cloudbase_init_conf.assert_called_once_with(
+            cloudbaseinit_base_dir, local_base_dir,
+            metadata_services=None, plugins=None, com_port='COM1')
+        mock_setup_existing_cbslinit_service.assert_called_once_with(
+            str(mock_uuid4.return_value), expected_image_path)
+        mock_create_service.assert_not_called()
+        mock_unload_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value)
+
+    def test__compile_static_ip_conf_from_registry(self):
+        self.conn.exec_ps_command.side_effect = [
+            'interface1\ninterface2',
+            '0',
+            '192.168.1.1',
+            '255.255.255.0',
+            '192.168.1.254',
+            '8.8.8.8',
+            '1',
+        ]
+        interfaces_reg_path = (windows.INTERFACES_PATH_FORMAT %
+                               mock.sentinel.key_name)
+
+        result = self.morphing_tools._compile_static_ip_conf_from_registry(
+            mock.sentinel.key_name)
+
+        self.conn.exec_ps_command.assert_has_calls([
+            mock.call(
+                "(((Get-ChildItem -Path '%s').Name | Select-String -Pattern "
+                "'[^\\\\]+$').Matches).Value" % interfaces_reg_path),
+            mock.call(
+                "(Get-ItemProperty -Path '%s\\interface1').EnableDHCP" %
+                interfaces_reg_path),
+            mock.call(
+                "(Get-ItemProperty -Path '%s\\interface1').IPAddress" %
+                interfaces_reg_path),
+            mock.call(
+                "(Get-ItemProperty -Path '%s\\interface1').SubnetMask" %
+                interfaces_reg_path),
+            mock.call(
+                "(Get-ItemProperty -Path '%s\\interface1').DefaultGateway" %
+                interfaces_reg_path),
+            mock.call(
+                "(Get-ItemProperty -Path '%s\\interface1').NameServer"
+                % interfaces_reg_path),
+            mock.call(
+                "(Get-ItemProperty -Path '%s\\interface2').EnableDHCP"
+                % interfaces_reg_path),
+        ])
+
+        expected_ips_info = [
+            {"ip_address": '192.168.1.1',
+             "prefix_length": 24,
+             "default_gateway": '192.168.1.254',
+             "dns_addresses": '8.8.8.8'}
+        ]
+        self.assertEqual(result, expected_ips_info)
+
+    def test_compile_static_ip_conf_from_registry_no_ip_or_subnet(self):
+        self.conn.exec_ps_command.side_effect = [
+            'interface1',
+            '0',
+            None,
+            None,
+        ]
+
+        interfaces_reg_path = (windows.INTERFACES_PATH_FORMAT %
+                               mock.sentinel.key_name)
+        with self.assertLogs('coriolis.osmorphing.windows',
+                             level=logging.WARNING):
+            self.morphing_tools._compile_static_ip_conf_from_registry(
+                mock.sentinel.key_name)
+
+        self.conn.exec_ps_command.assert_has_calls([
+            mock.call(
+                "(((Get-ChildItem -Path '%s').Name | Select-String -Pattern "
+                "'[^\\\\]+$').Matches).Value" % interfaces_reg_path),
+            mock.call("(Get-ItemProperty -Path '%s\\interface1').EnableDHCP" %
+                      interfaces_reg_path),
+            mock.call("(Get-ItemProperty -Path '%s\\interface1').IPAddress" % (
+                interfaces_reg_path)),
+            mock.call("(Get-ItemProperty -Path '%s\\interface1').SubnetMask" %
+                      interfaces_reg_path),
+        ])
+
+    def test_compile_static_ip_conf_from_registry_no_static_ip(self):
+        self.conn.exec_ps_command.side_effect = [
+            'interface1',
+            '1',
+        ]
+        interfaces_reg_path = (windows.INTERFACES_PATH_FORMAT %
+                               mock.sentinel.key_name)
+
+        with self.assertLogs('coriolis.osmorphing.windows',
+                             level=logging.DEBUG):
+            self.morphing_tools._compile_static_ip_conf_from_registry(
+                mock.sentinel.key_name)
+        self.conn.exec_ps_command.assert_has_calls([
+            mock.call(
+                "(((Get-ChildItem -Path '%s').Name | Select-String -Pattern "
+                "'[^\\\\]+$').Matches).Value" % interfaces_reg_path),
+            mock.call("(Get-ItemProperty -Path '%s\\interface1').EnableDHCP" %
+                      interfaces_reg_path),
+        ])
+
+    def test_check_ips_info(self):
+        nics_info = [
+            {'ip_addresses': [mock.sentinel.ip_address]}
+        ]
+        ips_info = [
+            {'ip_address': mock.sentinel.ip_address}
+        ]
+        self.morphing_tools._check_ips_info(nics_info, ips_info)
+
+    def test_check_ips_info_different_ips(self):
+        nics_info = [
+            {'ip_addresses': [
+                mock.sentinel.ip_address, mock.sentinel.ip_address2]}
+        ]
+        ips_info = [
+            {'ip_address': mock.sentinel.ip_address}
+        ]
+
+        self.assertRaises(exception.OSMorphingException,
+                          self.morphing_tools._check_ips_info,
+                          nics_info, ips_info)
+
+    @mock.patch.object(windows.utils, 'write_winrm_file')
+    def test__write_static_ip_script(self, mock_write_winrm_file):
+        nics_info = [
+            {'ip_addresses': ["10.1.10.10"]}
+        ]
+        ips_info = [
+            {'ip_address': "10.1.10.10"}
+        ]
+        self.morphing_tools._write_static_ip_script(
+            'C:', nics_info, ips_info)
+
+        contents = windows.STATIC_IP_SCRIPT_TEMPLATE % {
+            'nics_info': base64.b64encode(
+                json.dumps(nics_info).encode()).decode(),
+            'ips_info': base64.b64encode(
+                json.dumps(ips_info).encode()).decode(),
+        }
+        mock_write_winrm_file.assert_called_once_with(
+            self.morphing_tools._conn,
+            "C:\\LocalScripts\\01-static-ip-config.ps1",
+            contents.encode())
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools,
+        '_compile_static_ip_conf_from_registry'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_write_static_ip_script'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_unload_registry_hive'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_load_registry_hive'
+    )
+    @mock.patch.object(windows.uuid, 'uuid4')
+    def test_set_net_config(self, mock_uuid4, mock_load_registry_hive,
+                            mock_unload_registry_hive,
+                            mock_write_static_ip_script,
+                            mock_compile_static_ip_conf_from_registry):
+        dhcp = False
+        nics_info = [
+            {'ip_addresses': ["10.1.10.10"]}
+        ]
+        ips_info = [
+            {'ip_address': "10.1.10.10"}
+        ]
+        mock_compile_static_ip_conf_from_registry.return_value = ips_info
+
+        self.morphing_tools.set_net_config(nics_info, dhcp=dhcp)
+
+        mock_load_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value,
+            "%sWindows\\System32\\config\\SYSTEM" % self.os_root_dir)
+        mock_compile_static_ip_conf_from_registry.assert_called_once_with(
+            str(mock_uuid4.return_value))
+        mock_write_static_ip_script.assert_called_once_with(
+            "C:\\Cloudbase-Init",
+            nics_info,
+            mock_compile_static_ip_conf_from_registry.return_value)
+        mock_unload_registry_hive.assert_called_once_with(
+            "HKLM\\%s" % mock_uuid4.return_value)
+
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_get_cbslinit_base_dir'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools,
+        '_compile_static_ip_conf_from_registry'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_write_static_ip_script'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_unload_registry_hive'
+    )
+    @mock.patch.object(
+        windows.BaseWindowsMorphingTools, '_load_registry_hive'
+    )
+    @mock.patch.object(windows.BaseWindowsMorphingTools, '_check_ips_info')
+    def test_set_net_config_with_dhcp(
+            self, mock_check_ips_info, mock_load_registry_hive,
+            mock_unload_registry_hive, mock_write_static_ip_script,
+            mock_get_cbslinit_base_dir,
+            mock_compile_static_ip_conf_from_registry):
+        dhcp = True
+
+        result = self.morphing_tools.set_net_config(
+            mock.sentinel.nics_info, dhcp=dhcp)
+
+        mock_load_registry_hive.assert_not_called()
+        mock_get_cbslinit_base_dir.assert_not_called()
+        mock_compile_static_ip_conf_from_registry.assert_not_called()
+        mock_check_ips_info.assert_not_called()
+        mock_write_static_ip_script.assert_not_called()
+        mock_unload_registry_hive.assert_not_called()
+
+        self.assertIsNone(result)


### PR DESCRIPTION
This PR adds unit testing for the following modules:
* `osmorphing/amazon.py`
* `osmorphing/base.py`
* `osmorphing/centos.py`
* `osmorphing/coreos.py`
* `osmorphing/debian.py`
* `osmorphing/manager.py`
* `osmorphing/openwrt.py`
* `osmorphing/oracle.py`
* `osmorphing/redhat.py`
* `osmorphing/rocky.py`
* `osmorphing/suse.py`
* `osmorphing/ubuntu.py`
* `osmorphing/windows.py`