### PR TITLE
Enable unit test coverage checking

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Run unit tests with tox
       shell: bash
       run: |
-        tox -e py3,pep8 -v
+        tox -e py3,pep8,cover -v
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0.2
-envlist = py3,pep8
+envlist = py3,pep8,cover
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Enables `cover` tox env when creating PRs.