### PR TITLE
tests: Adds mock patch autospec fixture

### DIFF
--- a/coriolis/tests/__init__.py
+++ b/coriolis/tests/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from oslotest import mock_fixture
+
+# NOTE(claudiub): this needs to be called before any mock.patch calls are
+# being done, and especially before any other test classes load. This fixes
+# the mock.patch autospec issue:
+# https://github.com/testing-cabal/mock/issues/396
+mock_fixture.patch_mock_module()


### PR DESCRIPTION
When mocking something, there's the possibility to reference a property that does not exist, or call a method with invalid arguments, but the unit tests to keep passing, resulting in false positives.

We've seen this issue several times in OpenStack, and we have created and started using a mock patch fixture (can be seen in OpenStack Nova's ``test.py``) which enables autospec by default.

This guarantees 2 things: that the thing we're patching exists, and if it's callable, that the calls respect the callable's signature (e.g.: no unknown arguments can be used).