### PR TITLE
Skip fstab mountpoints that are not valid directory paths

### DIFF
--- a/coriolis/osmorphing/osmount/base.py
+++ b/coriolis/osmorphing/osmount/base.py
@@ -261,6 +261,13 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
 
             device = match.group(2)
             mountpoint = match.group(3)
+
+            if not mountpoint.startswith('/'):
+                LOG.warning(
+                    f"Skipping mountpoint that is not a valid directory: "
+                    f"{mountpoint}")
+                continue
+
             if mountpoint in mounts:
                 raise exception.CoriolisException(
                     "Mountpoint '%s' appears to be mounted twice in "


### PR DESCRIPTION
This commit aims to fix an issue where multiple swap partitions that have the same 'none' or 'swap' as mountpoint. In order to achieve this, the linux OSMount tools will skip any mountpoint that is not a valid directory.