### PR TITLE
Remove LVM system device filters for RedHat OSMount Tools

### DIFF
--- a/coriolis/osmorphing/osmount/redhat.py
+++ b/coriolis/osmorphing/osmount/redhat.py
@@ -22,6 +22,7 @@ class RedHatOSMountTools(base.BaseLinuxOSMountTools):
         super(RedHatOSMountTools, self).setup()
         self._exec_cmd("sudo -E yum install -y lvm2 psmisc")
         self._exec_cmd("sudo modprobe dm-mod")
+        self._exec_cmd("sudo rm -f /etc/lvm/devices/system.devices")
 
     def _allow_ssh_env_vars(self):
         self._exec_cmd('sudo sed -i -e "\$aAcceptEnv *" /etc/ssh/sshd_config')


### PR DESCRIPTION
System Device filters is a feature enabled by default on RHEL9-based images, which limits the LVM detection on a particular set of system devices, provided in the `system.devices` file. This is bad for the OSMount process, since it will fail to detect LVM volumes on the migrated partitions. Removing the `system.devices` file from the minion machine disables this feature and fixes the issue.