### PR TITLE
Handle wsgi and add CA file option

### DIFF
--- a/coriolis/keystone.py
+++ b/coriolis/keystone.py
@@ -15,6 +15,10 @@ opts = [
                default=None,
                help='Default auth URL to be used when not specified in the'
                ' migration\'s connection info.'),
+    cfg.StrOpt('cafile',
+               default=None,
+               help='The CA file used to validate openstack service'
+               ' API endpoints.'),
     cfg.IntOpt('identity_api_version',
                min=2, max=3,
                default=2,
@@ -126,6 +130,10 @@ def create_keystone_session(ctxt, connection_info={}):
             "username": username,
             "password": password,
         }
+
+    cafile = CONF.keystone.cafile
+    if cafile and cafile != "":
+        verify = cafile
 
     if not auth:
         project_name = connection_info.get("project_name", ctxt.project_name)

--- a/coriolis/service.py
+++ b/coriolis/service.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 import platform
+import sys
 
 from oslo_concurrency import processutils
 from oslo_config import cfg
@@ -98,6 +99,15 @@ def check_locks_dir_empty():
     LOG.info(
         "Successfully checked 'lock_path' directory '%s' exists and is empty.",
         locks_dir)
+
+
+def get_application():
+    worker_count, args = get_worker_count_from_args(sys.argv)
+    CONF(args[1:], project='coriolis', version="1.0.0")
+    utils.setup_logging()
+
+    loader = wsgi.Loader(CONF)
+    return loader.load_app("coriolis-api")
 
 
 class WSGIService(service.ServiceBase):


### PR DESCRIPTION
Thic change adds the ability to specify a CA cert file to use when validating requests to the rest of the openstack projects and adds a function that returns a WSGI app which can be used with `mod_wsgi` and similar.