### PR TITLE
Fix migration reservation deletion on internal cancellations

### DIFF
--- a/coriolis/conductor/rpc/server.py
+++ b/coriolis/conductor/rpc/server.py
@@ -2156,7 +2156,6 @@ class ConductorServerEndpoint(object):
                 constants.EXECUTION_LOCK_NAME_FORMAT % execution.id,
                 external=True):
             self._cancel_tasks_execution(ctxt, execution, force=force)
-        self._check_delete_reservation_for_transfer(migration)
 
     def _cancel_tasks_execution(
             self, ctxt, execution, requery=True, force=False):
@@ -3301,6 +3300,10 @@ class ConductorServerEndpoint(object):
                 "confirmation of its cancellation.",
                 task.id, task.status, final_status)
             execution = db_api.get_tasks_execution(ctxt, task.execution_id)
+            if execution.type == constants.EXECUTION_TYPE_MIGRATION:
+                action = db_api.get_action(
+                    ctxt, execution.action_id, include_task_info=False)
+                self._check_delete_reservation_for_transfer(action)
             self._advance_execution_state(ctxt, execution, requery=False)
 
     @parent_tasks_execution_synchronized


### PR DESCRIPTION
This patch makes sure that the migration reservation deletion is done on any migration task cancellation. Prior to this, internal cancellations (i.e. KeyboardInterrupt signals) that were raised internally did not result in a migration reservation deletion, leaving said cancelled migration licences as consumed. The reservation deletion was moved in the cancellation confirmation operation on conductor side, so all cancellation signals will be included in making sure the cancelled migration licence will be reverted.