### PR TITLE
`OSMount` - Fix handling of non-existent devices

### DIFF
--- a/coriolis/osmorphing/osmount/base.py
+++ b/coriolis/osmorphing/osmount/base.py
@@ -384,6 +384,10 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
             colls = line.split()
             if colls[0].startswith("/dev"):
                 dev_name = self._get_symlink_target(colls[0])
+                if not utils.test_ssh_path(self._ssh, dev_name):
+                    LOG.warn(
+                        "Device name %s not found, skipping mount.", dev_name)
+                    continue
                 ret.append(dev_name)
                 mounted_device_numbers.append(
                     self._exec_cmd(dev_nmb_cmd % dev_name).decode().rstrip())


### PR DESCRIPTION
This PR implements the following updates:
* Added a check to verify the existence of the `device` before attempting to `mount` it;
* Included a `unit test` for this scenario; 