### PR TITLE
Fix logging delay for worker task processes

### DIFF
--- a/coriolis/worker/rpc/server.py
+++ b/coriolis/worker/rpc/server.py
@@ -144,7 +144,6 @@ class WorkerServerEndpoint(object):
             except queue.Empty:
                 if not p.is_alive():
                     break
-            time.sleep(.2)
 
     def _get_custom_ld_path(self, original_ld_path, extra_library_paths):
         if not isinstance(extra_library_paths, list):


### PR DESCRIPTION
This patch removes the sleep added to avoid high CPU usage caused by an eventual infinite loop. It's not the case of infinite loops on logging queue, therefore it is safe to remove it.