### PR TITLE
Fix issue 'Permission denied' error due to repo permissions on redhat linux

### DIFF
--- a/coriolis/osmorphing/redhat.py
+++ b/coriolis/osmorphing/redhat.py
@@ -270,7 +270,12 @@ class BaseRedHatMorphingTools(base.BaseLinuxOSMorphingTools):
         installed_repos = []
         for file in repofiles:
             path = os.path.join(reposdir_path, file)
-            content = self._read_file(path).decode()
+            try:
+                content = self._read_file_sudo(path).decode()
+            except Exception as e:
+                LOG.warning(
+                    "Could not read yum repository file %s: %s", path, e)
+                continue
             for line in content.splitlines():
                 m = re.match(r'^\[(.+)\]$', line)
                 if m:

--- a/coriolis/tests/osmorphing/test_redhat.py
+++ b/coriolis/tests/osmorphing/test_redhat.py
@@ -453,15 +453,15 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         mock_exec_cmd_chroot.assert_called_once_with("yum clean all")
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
-    def test__find_yum_repos_found(self, mock_read_file, mock_list_dir):
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
+    def test__find_yum_repos_found(self, mock_read_file_sudo, mock_list_dir):
         mock_list_dir.return_value = ['file1.repo', 'file2.repo']
-        mock_read_file.return_value = b'[repo1]\n[repo2]'
+        mock_read_file_sudo.return_value = b'[repo1]\n[repo2]'
         repos_to_enable = ['repo1']
 
         result = self.morphing_tools._find_yum_repos(repos_to_enable)
 
-        mock_read_file.assert_has_calls([
+        mock_read_file_sudo.assert_has_calls([
             mock.call('etc/yum.repos.d/file1.repo'),
             mock.call('etc/yum.repos.d/file2.repo')
         ])
@@ -469,10 +469,11 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         self.assertEqual(result, ['repo1'])
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file')
-    def test__find_yum_repos_not_found(self, mock_read_file, mock_list_dir):
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
+    def test__find_yum_repos_not_found(self, mock_read_file_sudo,
+                                       mock_list_dir):
         mock_list_dir.return_value = ['file1.repo', 'file2.repo']
-        mock_read_file.return_value = b'[repo1]\n[repo2]'
+        mock_read_file_sudo.return_value = b'[repo1]\n[repo2]'
         repos_to_enable = ['repo3']
 
         with self.assertLogs('coriolis.osmorphing.redhat', level=logging.WARN):


### PR DESCRIPTION
- Fixes the 'Permission denied' error based on the read permission of the `/etc/yum.repos.d/`
- Sends a warning in case of repository not being parsed due to an error
- Updates the redhat tests to match the call of the new method