### PR TITLE
Add `hostname` to export_info

### DIFF
--- a/coriolis/schemas/vm_export_info_schema.json
+++ b/coriolis/schemas/vm_export_info_schema.json
@@ -22,6 +22,10 @@
       "type": "string",
       "description": "Human-readable identifier of the VM. It can be optionally used as an alternative to 'id' for identifying instances on platforms which also feature a non-ID naming scheme (e.g. VMWare VM paths)"
     },
+    "hostname": {
+      "type": "string",
+      "description": "Guest hostname of the VM."
+    },
     "dynamic_memory_enabled": {
       "type": "boolean",
       "description": "Indicates whether not the VM's physical memory was allocated dynamically."

--- a/coriolis/tasks/replica_tasks.py
+++ b/coriolis/tasks/replica_tasks.py
@@ -92,7 +92,15 @@ def _preserve_old_export_info_nic_ips(old_export_info, new_export_info):
                 new_info['ip_addresses'] = old_ips
 
 
+def _preserve_hostname_info(old_export_info, new_export_info):
+    old_hostname = old_export_info.get("hostname", "")
+    new_hostname = new_export_info.get("hostname", "")
+    if not new_hostname:
+        new_export_info['hostname'] = old_hostname
+
+
 def _update_export_info(old_export_info, result_export_info):
+    _preserve_hostname_info(old_export_info, result_export_info)
     _preserve_old_export_info_nic_ips(old_export_info, result_export_info)
 
 

--- a/coriolis/tests/tasks/data/test_hostname_update.yml
+++ b/coriolis/tests/tasks/data/test_hostname_update.yml
@@ -1,0 +1,28 @@
+# No hostnames
+- old_export_info: {}
+  new_export_info: {}
+  expected_export_info:
+    hostname: ""
+
+# Hostname in old info
+- old_export_info:
+    hostname: old.host.name
+  new_export_info: {}
+  expected_export_info:
+    hostname: old.host.name
+
+# Hostname in new info only
+- old_export_info:
+    hostname: ""
+  new_export_info:
+    hostname: "new.host.name"
+  expected_export_info:
+    hostname: "new.host.name"
+
+# Hostname update from old to new
+- old_export_info:
+    hostname: "old.host.name"
+  new_export_info:
+    hostname: "new.host.name"
+  expected_export_info:
+    hostname: "new.host.name"

--- a/coriolis/tests/tasks/test_replica_tasks.py
+++ b/coriolis/tests/tasks/test_replica_tasks.py
@@ -61,6 +61,13 @@ class ReplicaTasksTestCase(test_base.CoriolisBaseTestCase):
             old_export_info, new_export_info)
         self.assertEqual(new_export_info, expected_export_info)
 
+    @ddt.file_data("data/test_hostname_update.yml")
+    @ddt.unpack
+    def test__preserve_hostname_info(
+            self, old_export_info, new_export_info, expected_export_info):
+        replica_tasks._preserve_hostname_info(old_export_info, new_export_info)
+        self.assertEqual(new_export_info, expected_export_info)
+
 
 class GetInstanceInfoTaskTestCase(test_base.CoriolisBaseTestCase):
 


### PR DESCRIPTION
Adds `hostname` property to the instance export information, used in order to attempt hostname preservation