### PR TITLE
Pin oslo.context and oslo.config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ PyMySQL
 netifaces
 oslo.cache
 oslo.concurrency
-oslo.config
-oslo.context>=2.19.1
+oslo.config<9.8.0
+oslo.context<6.0.0
 oslo.db<=12.3.2
 oslo.i18n
 oslo.log


### PR DESCRIPTION
Since we're currently still using Openstack Antelope containers oslo has just had a few repos tagged May 16th which broke worker rpc registration. We'll have to pin the requirements until the rest of the codebase catches up.