### PR TITLE
Deployer manager safety fixes and improvements

### DIFF
--- a/coriolis/deployer_manager/rpc/server.py
+++ b/coriolis/deployer_manager/rpc/server.py
@@ -38,6 +38,7 @@ class DeployerManagerServerEndpoint:
         active_statuses = [
             constants.EXECUTION_STATUS_UNEXECUTED,
             constants.EXECUTION_STATUS_RUNNING,
+            constants.EXECUTION_STATUS_AWAITING_MINION_ALLOCATIONS,
         ]
         error_statuses = [
             constants.EXECUTION_STATUS_ERROR,


### PR DESCRIPTION
This PR includes the following:

- **Fix deployer manager failing deployments when awaiting for minions**

If the deployer transfer starts with a minion pool, the deployer manager
would've considered the `AWAITING_MINION_ALLOCATIONS` status as an invalid
one, and thus error out the automatically launched deployment. This patch
adds this minion status as an active and valid one, and properly waits for
the deployer to finish with minion refreshment and the transfer execution as
well.

 - **Wait for deployer threads**

This patch makes sure that all deployer manager threads finish before launching
new ones. By immediately launching new ones, there was a risk where after the
deployer completes, the threads would simultaneously create deployment
executions, which breaks deployments and transfers, as deployments are designed
to only contain a single execution.

- **Wait for successful deployer to change the deployment's status**

This patch makes sure that after the deployer's confirmation the deployment
actually goes out of the `PENDING` status, so it won't get picked up again
when the deployer manager launches new threads.

- **Improve auto-deployment lock safety**

This patch prevents minion-pooled deployments from locking, since it would've
locked the deployment resource twice. As an improvement, the deployment
resource gets locked separately when getting deployment information inside
the deployer confirmation method. It also improves transfer locking safety
when creating deployment execution.
