### PR TITLE
instance user_scripts fix on deployments

### DIFF
--- a/coriolis/api/v1/deployments.py
+++ b/coriolis/api/v1/deployments.py
@@ -80,9 +80,6 @@ class DeploymentsController(api_wsgi.Controller):
             'instance_osmorphing_minion_pool_mappings', {})
         user_scripts = deployment.get('user_scripts', {})
         api_utils.validate_user_scripts(user_scripts)
-        user_scripts = api_utils.normalize_user_scripts(
-            user_scripts, deployment.get("instances", []))
-
         return (
             transfer_id, force, clone_disks, skip_os_morphing,
             instance_osmorphing_minion_pool_mappings,

--- a/coriolis/api/v1/transfers.py
+++ b/coriolis/api/v1/transfers.py
@@ -124,8 +124,6 @@ class TransferController(api_wsgi.Controller):
 
         user_scripts = transfer.get('user_scripts', {})
         api_utils.validate_user_scripts(user_scripts)
-        user_scripts = api_utils.normalize_user_scripts(
-            user_scripts, instances)
 
         # NOTE(aznashwan): we validate the destination environment for the
         # import provider before appending the 'storage_mappings' parameter
@@ -368,8 +366,6 @@ class TransferController(api_wsgi.Controller):
 
         user_scripts = merged_body['user_scripts']
         api_utils.validate_user_scripts(user_scripts)
-        merged_body['user_scripts'] = api_utils.normalize_user_scripts(
-            user_scripts, transfer.get('instances', []))
 
         return merged_body
 

--- a/coriolis/api/v1/utils.py
+++ b/coriolis/api/v1/utils.py
@@ -117,22 +117,6 @@ def validate_user_scripts(user_scripts):
     return user_scripts
 
 
-def normalize_user_scripts(user_scripts, instances):
-    """ Removes instance user_scripts if said instance is not one of the
-        selected instances for the replica/migration """
-    if user_scripts is None:
-        user_scripts = {}
-    for instance in list(user_scripts.get('instances', {}).keys()):
-        if instance not in instances:
-            LOG.warn("Removing provided instance '%s' from user_scripts body "
-                     "because it's not included in one of the selected "
-                     "instances for this replica/migration: %s",
-                     instance, instances)
-            user_scripts['instances'].pop(instance, None)
-
-    return user_scripts
-
-
 def validate_instances_list_for_transfer(instances):
     if not instances:
         raise exception.InvalidInput(

--- a/coriolis/tests/api/v1/test_transfers.py
+++ b/coriolis/tests/api/v1/test_transfers.py
@@ -119,13 +119,11 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
     @mock.patch.object(api_utils, 'validate_network_map')
     @mock.patch.object(endpoints_api.API, 'validate_target_environment')
     @mock.patch.object(api_utils, 'validate_user_scripts')
-    @mock.patch.object(api_utils, 'normalize_user_scripts')
     @mock.patch.object(api_utils, 'validate_storage_mappings')
     @ddt.file_data('data/transfers_validate_create_body.yml')
     def test_validate_create_body(
         self,
         mock_validate_storage_mappings,
-        mock_normalize_user_scripts,
         mock_validate_user_scripts,
         mock_validate_target_environment,
         mock_validate_network_map,
@@ -147,7 +145,6 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
         instances = transfer.get('instances')
         storage_mappings = transfer.get('storage_mappings')
         mock_validate_instances_list_for_transfer.return_value = instances
-        mock_normalize_user_scripts.return_value = user_scripts
 
         if exception_raised:
             self.assertRaisesRegex(
@@ -178,8 +175,6 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
             mock_validate_target_environment.assert_called_once_with(
                 ctxt, destination_endpoint_id, destination_environment)
             mock_validate_user_scripts.assert_called_once_with(user_scripts)
-            mock_normalize_user_scripts.assert_called_once_with(
-                user_scripts, instances)
             mock_validate_storage_mappings.assert_called_once_with(
                 storage_mappings)
 
@@ -368,7 +363,6 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
         mock_get_updated_user_scripts.assert_called_once_with(
             "mock_scripts", "mock_new_scripts")
 
-    @mock.patch.object(api_utils, 'normalize_user_scripts')
     @mock.patch.object(api_utils, 'validate_user_scripts')
     @mock.patch.object(api_utils, 'validate_storage_mappings')
     @mock.patch.object(api_utils, 'validate_network_map')
@@ -387,7 +381,6 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
         mock_validate_network_map,
         mock_validate_storage_mappings,
         mock_validate_user_scripts,
-        mock_normalize_user_scripts,
         config,
         expected_result
     ):
@@ -398,8 +391,6 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
         id = mock.sentinel.id
         mock_get_transfer.return_value = transfer
         mock_get_merged_transfer_values.return_value = transfer_body
-        mock_normalize_user_scripts.return_value = transfer_body[
-            'user_scripts']
 
         result = testutils.get_wrapped_function(
             self.transfers._validate_update_body)(
@@ -429,8 +420,6 @@ class TransferControllerTestCase(test_base.CoriolisBaseTestCase):
             transfer_body['storage_mappings'])
         mock_validate_user_scripts.assert_called_once_with(
             transfer_body['user_scripts'])
-        mock_normalize_user_scripts.assert_called_once_with(
-            transfer_body['user_scripts'], transfer['instances'])
 
     @mock.patch.object(api.API, 'get_transfer')
     @ddt.file_data('data/transfers_validate_update_body_raises.yml')

--- a/coriolis/tests/api/v1/test_utils.py
+++ b/coriolis/tests/api/v1/test_utils.py
@@ -223,43 +223,6 @@ class UtilsTestCase(test_base.CoriolisBaseTestCase):
             user_scripts
         )
 
-    def test_normalize_user_scripts(
-        self
-    ):
-        user_scripts = {
-            'instances': {
-                "mock_instance_1": "mock_value_1",
-                "mock_instance_2": "mock_value_2"
-            }
-        }
-        instances = ["mock_instance_2", "mock_instance_3"]
-        expected_result = {
-            'instances': {
-                "mock_instance_2": "mock_value_2"
-            }
-        }
-
-        with self.assertLogs('coriolis.api.v1.utils', level='WARN'):
-            result = utils.normalize_user_scripts(user_scripts, instances)
-
-        self.assertEqual(
-            expected_result,
-            result
-        )
-
-    def test_normalize_user_scripts_none(
-        self
-    ):
-        user_scripts = None
-        instances = None
-
-        result = utils.normalize_user_scripts(user_scripts, instances)
-
-        self.assertEqual(
-            {},
-            result
-        )
-
     @ddt.file_data('data/utils_validate_instances_list_for_transfer.yml')
     def test_validate_instances_list_for_transfer(
         self,


### PR DESCRIPTION
This PR addresses an issue where instance user scripts added during deployment were not actually processed, which caused them to be unavailable during OS morphing.

To fix this, the _normalize_user_scripts logic was refactored and moved from coriolis.api.v1.utils to the ConductorServerEndpoint class, where it is now used only during the deployment stage of the transfer.

Related unit tests have also been refactored and moved into test_server.py.