### PR TITLE
Fix missing `kwarg` in `get_transfers` RPC method

### DIFF
--- a/coriolis/conductor/rpc/server.py
+++ b/coriolis/conductor/rpc/server.py
@@ -1191,7 +1191,7 @@ class ConductorServerEndpoint(object):
     def get_transfers(ctxt, include_tasks_executions=False,
                       include_task_info=False):
         return db_api.get_transfers(
-            ctxt, include_tasks_executions,
+            ctxt, include_tasks_executions=include_tasks_executions,
             include_task_info=include_task_info, to_dict=True)
 
     @transfer_synchronized

--- a/coriolis/tests/conductor/rpc/test_server.py
+++ b/coriolis/tests/conductor/rpc/test_server.py
@@ -1641,7 +1641,7 @@ class ConductorServerEndpointTestCase(test_base.CoriolisBaseTestCase):
         )
         mock_get_transfers.assert_called_once_with(
             mock.sentinel.context,
-            False,
+            include_tasks_executions=False,
             include_task_info=False,
             to_dict=True
         )


### PR DESCRIPTION
* The `get_transfers()` RPC method was passing `include_tasks_executions` as a positional argument instead of a keyword argument to the database API, causing incorrect parameter mapping and empty transfer lists.
