### PR TITLE
Enhance `OSMorphing` tools with `latest` flag support and improved version detection

### DIFF
--- a/coriolis/osmorphing/base.py
+++ b/coriolis/osmorphing/base.py
@@ -127,6 +127,8 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
 
     _packages = {}
 
+    latest = False
+
     def __init__(self, conn, os_root_dir, os_root_dev, hypervisor,
                  event_manager, detected_os_info, osmorphing_parameters,
                  operation_timeout=None):
@@ -179,6 +181,12 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
                 "Version '%s' smaller than the minimum of '%s' for "
                 "release: %s", version_float, minimum, version)
             return False
+
+        if cls.latest:
+            LOG.debug(
+                "Skipping remaining version checks for latest osmorphing tool "
+                "class: %s", cls.__name__)
+            return True
 
         if maximum:
             if maximum == minimum and version_float == minimum:

--- a/coriolis/osmorphing/manager.py
+++ b/coriolis/osmorphing/manager.py
@@ -85,6 +85,27 @@ def get_osmorphing_tools_class_for_provider(
         "and 'osmorphing_info' %s: %s",
         type(provider), os_type, osmorphing_info, available_tools_cls)
 
+    module_classes = {}
+    for toolscls in available_tools_cls:
+        module_name = toolscls.__module__
+        if module_name not in module_classes:
+            module_classes[module_name] = []
+        module_classes[module_name].append(toolscls)
+
+    for module_name, classes in module_classes.items():
+        latest_flags = [getattr(cls, 'latest', False) for cls in classes]
+        latest_count = sum(latest_flags)
+
+        if latest_count > 1:
+            latest_classes = [
+                cls.__name__ for cls in classes if getattr(
+                    cls, 'latest', False)]
+            raise exception.InvalidOSMorphingTools(
+                "Provider class '%s' returned multiple 'latest' OSMorphing "
+                "tools from module '%s': %s. Only one class per module "
+                "can be marked as 'latest'." % (
+                    type(provider), module_name, latest_classes))
+
     osmorphing_base_class = base_osmorphing.BaseOSMorphingTools
     for toolscls in available_tools_cls:
         if not issubclass(toolscls, osmorphing_base_class):

--- a/coriolis/osmorphing/osdetect/centos.py
+++ b/coriolis/osmorphing/osdetect/centos.py
@@ -22,10 +22,11 @@ class CentOSOSDetectTools(base.BaseLinuxOSDetectTools):
             release_info = self._read_file(
                 redhat_release_path).decode().splitlines()
             if release_info:
-                m = re.match(r"^(.*) release ([0-9](\.[0-9])*)( \(.*\))?.*$",
-                             release_info[0].strip())
+                m = re.match(
+                    r"^(.*) release ([0-9]+(?:\.[0-9]+)*)( \(.*\))?.*$",
+                    release_info[0].strip())
                 if m:
-                    distro, version, _, _ = m.groups()
+                    distro, version, _ = m.groups()
                     if CENTOS_DISTRO_IDENTIFIER not in distro:
                         LOG.debug(
                             "Distro does not appear to be a CentOS: %s",


### PR DESCRIPTION
This PR includes the following changes:

- Fix `CentOS` version detection for multi-digit releases;
- Add `NetworkManager` support for `CentOS` Stream 9+ `network configuration`;
- Implement `latest` flag system for OSMorphing tools;