### PR TITLE
Update enable_repo from osmorphing for all redhat based OSes

### DIFF
--- a/coriolis/osmorphing/amazon.py
+++ b/coriolis/osmorphing/amazon.py
@@ -1,11 +1,17 @@
 # Copyright 2023 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+from oslo_log import log as logging
+
+from coriolis import exception
 from coriolis.osmorphing.osdetect import amazon as amazon_detect
 from coriolis.osmorphing import redhat
+from coriolis import utils
 
 
 AMAZON_DISTRO_NAME_IDENTIFIER = amazon_detect.AMAZON_DISTRO_NAME
+
+LOG = logging.getLogger(__name__)
 
 
 class BaseAmazonLinuxOSMorphingTools(redhat.BaseRedHatMorphingTools):
@@ -19,3 +25,39 @@ class BaseAmazonLinuxOSMorphingTools(redhat.BaseRedHatMorphingTools):
             return False
         return cls._version_supported_util(
             detected_os_info['release_version'], minimum=2)
+
+    def enable_repos(self, repo_names):
+        """Enable repositories for Amazon Linux.
+
+        Uses yum-config-manager for Amazon Linux 2,
+        dnf config-manager for Amazon Linux 2023 and later.
+        """
+        if not repo_names:
+            return
+
+        # Determine package manager based on version
+        # Amazon Linux 2 has version "2", AL2023 has version "2023"
+        try:
+            major_version = int(str(self._version).split('.')[0])
+        except (ValueError, AttributeError):
+            # Fallback to yum if version parsing fails
+            major_version = 2
+
+        if major_version >= 2023:
+            # Amazon Linux 2023+ uses dnf
+            config_manager = 'dnf config-manager'
+            enable_flag = '--set-enabled %s'
+        else:
+            # Amazon Linux 2 and earlier use yum
+            config_manager = 'yum-config-manager'
+            enable_flag = '--enable %s'
+
+        for repo in repo_names:
+            cmd = '%s %s' % (config_manager, enable_flag % repo)
+            try:
+                self._exec_cmd_chroot(cmd)
+                LOG.info("Enabled repository '%s' using %s",
+                         repo, config_manager)
+            except exception.CoriolisException:
+                LOG.warning(f"Failed to enable repository {repo}. "
+                            f"Error was: {utils.get_exception_details()}")

--- a/coriolis/osmorphing/centos.py
+++ b/coriolis/osmorphing/centos.py
@@ -1,13 +1,18 @@
 # Copyright 2020 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+from oslo_log import log as logging
 
+from coriolis import exception
 from coriolis.osmorphing.osdetect import centos as centos_detect
 from coriolis.osmorphing import redhat
+from coriolis import utils
 
 
 CENTOS_DISTRO_IDENTIFIER = centos_detect.CENTOS_DISTRO_IDENTIFIER
 CENTOS_STREAM_DISTRO_IDENTIFIER = centos_detect.CENTOS_STREAM_DISTRO_IDENTIFIER
+
+LOG = logging.getLogger(__name__)
 
 
 class BaseCentOSMorphingTools(redhat.BaseRedHatMorphingTools):
@@ -22,3 +27,33 @@ class BaseCentOSMorphingTools(redhat.BaseRedHatMorphingTools):
             return False
         return cls._version_supported_util(
             detected_os_info['release_version'], minimum=6)
+
+    def enable_repos(self, repo_names):
+        """Enable repositories for CentOS.
+
+        Uses yum-config-manager for CentOS 7 and earlier,
+        dnf config-manager for CentOS 8 and later.
+        """
+        if not repo_names:
+            return
+
+        # Determine package manager based on version
+        major_version = int(str(self._version).split('.')[0])
+        if major_version >= 8:
+            # CentOS 8+ uses dnf
+            config_manager = 'dnf config-manager'
+            enable_flag = '--set-enabled %s'
+        else:
+            # CentOS 7 and earlier use yum
+            config_manager = 'yum-config-manager'
+            enable_flag = '--enable %s'
+
+        for repo in repo_names:
+            cmd = '%s %s' % (config_manager, enable_flag % repo)
+            try:
+                self._exec_cmd_chroot(cmd)
+                LOG.info("Enabled repository '%s' using %s",
+                         repo, config_manager)
+            except exception.CoriolisException:
+                LOG.warning(f"Failed to enable repository {repo}. "
+                            f"Error was: {utils.get_exception_details()}")

--- a/coriolis/osmorphing/oracle.py
+++ b/coriolis/osmorphing/oracle.py
@@ -1,13 +1,17 @@
 # Copyright 2016 Cloudbase Solutions Srl
 # All Rights Reserved.
 
-import uuid
+from oslo_log import log as logging
 
+from coriolis import exception
 from coriolis.osmorphing.osdetect import oracle as oracle_detect
 from coriolis.osmorphing import redhat
+from coriolis import utils
 
 
 ORACLE_DISTRO_IDENTIFIER = oracle_detect.ORACLE_DISTRO_IDENTIFIER
+
+LOG = logging.getLogger(__name__)
 
 
 class BaseOracleMorphingTools(redhat.BaseRedHatMorphingTools):
@@ -20,34 +24,32 @@ class BaseOracleMorphingTools(redhat.BaseRedHatMorphingTools):
         return cls._version_supported_util(
             detected_os_info['release_version'], minimum=6)
 
-    def _get_oracle_repos(self):
-        repos = []
-        major_version = int(self._version.split(".")[0])
-        uekr_version = int(major_version) - 2
-        if major_version < 8:
-            repo_file_path = (
-                '/etc/yum.repos.d/%s.repo' % str(uuid.uuid4()))
-            self._exec_cmd_chroot(
-                "curl -L http://public-yum.oracle.com/public-yum-ol%s.repo "
-                "-o %s" % (major_version, repo_file_path))
-            # During OSMorphing, we temporarily enable needed package repos,
-            # so we make sure we disable all downloaded repos here.
-            self._exec_cmd_chroot(
-                'sed -i "s/^enabled=1$/enabled=0/g" %s' % repo_file_path)
+    def enable_repos(self, repo_names):
+        """Enable repositories for Oracle Linux.
 
-            repos_to_enable = ["ol%s_software_collections" % major_version,
-                               "ol%s_addons" % major_version,
-                               "ol%s_UEKR" % major_version,
-                               "ol%s_latest" % major_version]
-            repos = self._find_yum_repos(repos_to_enable)
+        Uses yum-config-manager for OL7 and earlier,
+        dnf config-manager for OL8 and later.
+        """
+        if not repo_names:
+            return
+
+        # Determine package manager based on version
+        major_version = int(str(self._version).split('.')[0])
+        if major_version >= 8:
+            # OL8+ uses dnf
+            config_manager = 'dnf config-manager'
+            enable_flag = '--set-enabled %s'
         else:
-            self._yum_install(
-                ['oraclelinux-release-el%s' % major_version],
-                self._find_yum_repos(['ol%s_baseos_latest' % major_version]))
-            repos_to_enable = ["ol%s_baseos_latest" % major_version,
-                               "ol%s_appstream" % major_version,
-                               "ol%d_addons" % major_version,
-                               "ol%s_UEKR%s" % (major_version, uekr_version)]
-            repos = self._find_yum_repos(repos_to_enable)
+            # OL7 and earlier use yum
+            config_manager = 'yum-config-manager'
+            enable_flag = '--enable %s'
 
-        return repos
+        for repo in repo_names:
+            cmd = '%s %s' % (config_manager, enable_flag % repo)
+            try:
+                self._exec_cmd_chroot(cmd)
+                LOG.info("Enabled repository '%s' using %s",
+                         repo, config_manager)
+            except exception.CoriolisException:
+                LOG.warning(f"Failed to enable repository {repo}. "
+                            f"Error was: {utils.get_exception_details()}")

--- a/coriolis/osmorphing/rocky.py
+++ b/coriolis/osmorphing/rocky.py
@@ -1,11 +1,17 @@
 # Copyright 2023 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+from oslo_log import log as logging
+
+from coriolis import exception
 from coriolis.osmorphing import centos
 from coriolis.osmorphing.osdetect import rocky as rocky_osdetect
+from coriolis import utils
 
 
 ROCKY_LINUX_DISTRO_IDENTIFIER = rocky_osdetect.ROCKY_LINUX_DISTRO_IDENTIFIER
+
+LOG = logging.getLogger(__name__)
 
 
 class BaseRockyLinuxMorphingTools(centos.BaseCentOSMorphingTools):
@@ -19,3 +25,23 @@ class BaseRockyLinuxMorphingTools(centos.BaseCentOSMorphingTools):
             return False
         return cls._version_supported_util(
             detected_os_info['release_version'], minimum=8)
+
+    def enable_repos(self, repo_names):
+        """Enable repositories for Rocky Linux.
+
+        Uses dnf config-manager for all Rocky Linux versions (8+).
+        """
+        if not repo_names:
+            return
+
+        # Rocky Linux only exists as version 8+, always uses dnf
+        config_manager = 'dnf config-manager'
+        for repo in repo_names:
+            cmd = '%s --set-enabled %s' % (config_manager, repo)
+            try:
+                self._exec_cmd_chroot(cmd)
+                LOG.info("Enabled repository '%s' using %s",
+                         repo, config_manager)
+            except exception.CoriolisException:
+                LOG.warning(f"Failed to enable repository {repo}. "
+                            f"Error was: {utils.get_exception_details()}")

--- a/coriolis/tests/osmorphing/test_amazon.py
+++ b/coriolis/tests/osmorphing/test_amazon.py
@@ -1,13 +1,35 @@
 # Copyright 2024 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+import logging
+from unittest import mock
 
+import ddt
+
+from coriolis import exception
 from coriolis.osmorphing import amazon
+from coriolis.osmorphing import base
 from coriolis.tests import test_base
 
 
+@ddt.ddt
 class BaseAmazonLinuxOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
     """Test suite for the BaseAmazonLinuxOSMorphingTools class."""
+
+    def setUp(self):
+        super(BaseAmazonLinuxOSMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': amazon.AMAZON_DISTRO_NAME_IDENTIFIER,
+            'release_version': '2',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.enable_repos = ['repo1', 'repo2']
+        self.morphing_tools = amazon.BaseAmazonLinuxOSMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
+            mock.sentinel.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters)
 
     def test_check_os_supported(self):
         detected_os_info = {
@@ -28,3 +50,39 @@ class BaseAmazonLinuxOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             detected_os_info)
 
         self.assertFalse(result)
+
+    @ddt.data(
+        # Amazon Linux 2 and earlier use yum-config-manager.
+        ('2', 'yum-config-manager --enable'),
+        # Amazon Linux 2023+ uses dnf config-manager.
+        ('2023', 'dnf config-manager --set-enabled'),
+    )
+    @ddt.unpack
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos(self, version, expected_cmd, mock_exec_cmd_chroot):
+        self.morphing_tools._version = version
+
+        self.morphing_tools.enable_repos(self.enable_repos)
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("%s repo1" % expected_cmd),
+            mock.call("%s repo2" % expected_cmd),
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_empty(self, mock_exec_cmd_chroot):
+        self.morphing_tools.enable_repos([])
+
+        mock_exec_cmd_chroot.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_with_exception(self, mock_exec_cmd_chroot):
+        self.morphing_tools._version = '2'
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        with self.assertLogs(
+                'coriolis.osmorphing.amazon', level=logging.WARN):
+            self.morphing_tools.enable_repos(['repo1'])
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "yum-config-manager --enable repo1")

--- a/coriolis/tests/osmorphing/test_centos.py
+++ b/coriolis/tests/osmorphing/test_centos.py
@@ -1,13 +1,35 @@
 # Copyright 2024 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+import logging
+from unittest import mock
 
+import ddt
+
+from coriolis import exception
+from coriolis.osmorphing import base
 from coriolis.osmorphing import centos
 from coriolis.tests import test_base
 
 
+@ddt.ddt
 class BaseCentOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
     """Test suite for the BaseCentOSMorphingTools class."""
+
+    def setUp(self):
+        super(BaseCentOSMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': centos.CENTOS_DISTRO_IDENTIFIER,
+            'release_version': '7',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.enable_repos = ['repo1', 'repo2']
+        self.morphing_tools = centos.BaseCentOSMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
+            mock.sentinel.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters)
 
     def test_check_os_supported(self):
         detected_os_info = {
@@ -28,3 +50,41 @@ class BaseCentOSMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             detected_os_info)
 
         self.assertFalse(result)
+
+    @ddt.data(
+        # CentOS 7 and earlier use yum-config-manager.
+        ('6', 'yum-config-manager --enable'),
+        ('7', 'yum-config-manager --enable'),
+        # CentOS 8+ uses dnf config-manager.
+        ('8', 'dnf config-manager --set-enabled'),
+        ('9', 'dnf config-manager --set-enabled'),
+    )
+    @ddt.unpack
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos(self, version, expected_cmd, mock_exec_cmd_chroot):
+        self.morphing_tools._version = version
+
+        self.morphing_tools.enable_repos(self.enable_repos)
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("%s repo1" % expected_cmd),
+            mock.call("%s repo2" % expected_cmd),
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_empty(self, mock_exec_cmd_chroot):
+        self.morphing_tools.enable_repos([])
+
+        mock_exec_cmd_chroot.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_with_exception(self, mock_exec_cmd_chroot):
+        self.morphing_tools._version = '7'
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        with self.assertLogs(
+                'coriolis.osmorphing.centos', level=logging.WARN):
+            self.morphing_tools.enable_repos(['repo1'])
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "yum-config-manager --enable repo1")

--- a/coriolis/tests/osmorphing/test_oracle.py
+++ b/coriolis/tests/osmorphing/test_oracle.py
@@ -1,15 +1,19 @@
 # Copyright 2024 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+import logging
 from unittest import mock
 
+import ddt
+
+from coriolis import exception
 from coriolis.osmorphing import base
 from coriolis.osmorphing import oracle
 from coriolis.osmorphing.osdetect import oracle as oracle_detect
-from coriolis.osmorphing import redhat
 from coriolis.tests import test_base
 
 
+@ddt.ddt
 class BaseOracleMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
     """Test case for the BaseOracleMorphingTools class."""
 
@@ -21,6 +25,7 @@ class BaseOracleMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             'release_version': '6',
             'friendly_release_name': mock.sentinel.friendly_release_name,
         }
+        self.enable_repos = ['repo1', 'repo2']
         self.oracle_morphing_tools = oracle.BaseOracleMorphingTools(
             mock.sentinel.conn, mock.sentinel.os_root_dir,
             mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
@@ -41,52 +46,39 @@ class BaseOracleMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
 
         self.assertFalse(result)
 
+    @ddt.data(
+        # OL7 and earlier use yum-config-manager.
+        ('6', 'yum-config-manager --enable'),
+        ('7', 'yum-config-manager --enable'),
+        # OL8+ uses dnf config-manager.
+        ('8', 'dnf config-manager --set-enabled'),
+    )
+    @ddt.unpack
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
-    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_find_yum_repos')
-    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
-    def test__get_oracle_repos(self, mock_yum_install, mock_find_yum_repos,
-                               mock_exec_cmd_chroot):
-        self.oracle_morphing_tools._version = '10'
+    def test_enable_repos(self, version, expected_cmd, mock_exec_cmd_chroot):
+        self.oracle_morphing_tools._version = version
 
-        result = self.oracle_morphing_tools._get_oracle_repos()
+        self.oracle_morphing_tools.enable_repos(self.enable_repos)
 
-        self.assertEqual(result, mock_find_yum_repos.return_value)
-
-        mock_find_yum_repos.assert_has_calls([
-            mock.call(["ol10_baseos_latest"]),
-            mock.call([
-                "ol10_baseos_latest",
-                "ol10_appstream",
-                "ol10_addons",
-                "ol10_UEKR8"
-            ]),
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("%s repo1" % expected_cmd),
+            mock.call("%s repo2" % expected_cmd),
         ])
-        mock_yum_install.assert_called_once_with(
-            ['oraclelinux-release-el10'], mock_find_yum_repos.return_value)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_empty(self, mock_exec_cmd_chroot):
+        self.oracle_morphing_tools.enable_repos([])
+
         mock_exec_cmd_chroot.assert_not_called()
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
-    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_find_yum_repos')
-    @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
-    @mock.patch.object(oracle.uuid, 'uuid4')
-    def test__get_oracle_repos_major_version_lt_8(
-            self, mock_uuid4, mock_yum_install, mock_find_yum_repos,
-            mock_exec_cmd_chroot):
-        result = self.oracle_morphing_tools._get_oracle_repos()
+    def test_enable_repos_with_exception(self, mock_exec_cmd_chroot):
+        self.oracle_morphing_tools._version = '7'
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
 
-        self.assertEqual(result, mock_find_yum_repos.return_value)
+        with self.assertLogs(
+                'coriolis.osmorphing.oracle', level=logging.WARN):
+            self.oracle_morphing_tools.enable_repos(['repo1'])
 
-        mock_find_yum_repos.assert_called_once_with([
-            "ol6_software_collections",
-            "ol6_addons",
-            "ol6_UEKR",
-            "ol6_latest"
-        ])
-        mock_yum_install.assert_not_called()
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call(
-                "curl -L http://public-yum.oracle.com/public-yum-ol6.repo "
-                "-o /etc/yum.repos.d/%s.repo" % mock_uuid4.return_value),
-            mock.call('sed -i "s/^enabled=1$/enabled=0/g" %s' % (
-                "/etc/yum.repos.d/%s.repo" % mock_uuid4.return_value))
-        ])
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "yum-config-manager --enable repo1")

--- a/coriolis/tests/osmorphing/test_redhat.py
+++ b/coriolis/tests/osmorphing/test_redhat.py
@@ -326,11 +326,11 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     def test__yum_install(self, mock_exec_cmd_chroot):
-        self.morphing_tools._yum_install(self.package_names, self.enable_repos)
+        self.morphing_tools._yum_install(self.package_names)
 
         mock_exec_cmd_chroot.assert_called_once_with(
             "yum install package1 package2 -y "
-            "--enablerepo=repo1 --enablerepo=repo2"
+            "--setopt=strict=1 --setopt=skip_missing_names_on_install=0"
         )
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
@@ -340,7 +340,7 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         self.assertRaises(
             exception.FailedPackageInstallationException,
             self.morphing_tools._yum_install,
-            self.package_names, self.enable_repos
+            self.package_names
         )
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
@@ -384,32 +384,31 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
 
         mock_exec_cmd_chroot.assert_called_once_with("yum clean all")
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
-    def test__find_yum_repos_found(self, mock_read_file_sudo, mock_list_dir):
-        mock_list_dir.return_value = ['file1.repo', 'file2.repo']
-        mock_read_file_sudo.return_value = '[repo1]\n[repo2]'
-        repos_to_enable = ['repo1']
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos(self, mock_exec_cmd_chroot):
+        self.morphing_tools.enable_repos(self.enable_repos)
 
-        result = self.morphing_tools._find_yum_repos(repos_to_enable)
-
-        mock_read_file_sudo.assert_has_calls([
-            mock.call('etc/yum.repos.d/file1.repo'),
-            mock.call('etc/yum.repos.d/file2.repo')
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("subscription-manager repos --enable=repo1"),
+            mock.call("subscription-manager repos --enable=repo2"),
         ])
 
-        self.assertEqual(result, ['repo1'])
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_empty(self, mock_exec_cmd_chroot):
+        self.morphing_tools.enable_repos([])
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_list_dir')
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_read_file_sudo')
-    def test__find_yum_repos_not_found(self, mock_read_file_sudo,
-                                       mock_list_dir):
-        mock_list_dir.return_value = ['file1.repo', 'file2.repo']
-        mock_read_file_sudo.return_value = '[repo1]\n[repo2]'
-        repos_to_enable = ['repo3']
+        mock_exec_cmd_chroot.assert_not_called()
 
-        with self.assertLogs('coriolis.osmorphing.redhat', level=logging.WARN):
-            self.morphing_tools._find_yum_repos(repos_to_enable)
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        with self.assertLogs(
+                'coriolis.osmorphing.redhat', level=logging.WARN):
+            self.morphing_tools.enable_repos(['repo1'])
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "subscription-manager repos --enable=repo1")
 
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_clean_all')
@@ -451,14 +450,16 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         mock_post_packages_install.assert_called_once_with(self.package_names)
 
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')
+    @mock.patch.object(redhat.BaseRedHatMorphingTools, 'enable_repos')
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_get_repos_to_enable')
     def test_install_packages(self, mock_get_repos_to_enable,
-                              mock_yum_install):
+                              mock_enable_repos, mock_yum_install):
         self.morphing_tools.install_packages(self.package_names)
 
         mock_get_repos_to_enable.assert_called_once()
-        mock_yum_install.assert_called_once_with(
-            self.package_names, mock_get_repos_to_enable.return_value)
+        mock_enable_repos.assert_called_once_with(
+            mock_get_repos_to_enable.return_value)
+        mock_yum_install.assert_called_once_with(self.package_names)
 
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_uninstall')
     def test_uninstall_packages(self, mock_yum_uninstall):

--- a/coriolis/tests/osmorphing/test_rocky.py
+++ b/coriolis/tests/osmorphing/test_rocky.py
@@ -1,13 +1,32 @@
 # Copyright 2024 Cloudbase Solutions Srl
 # All Rights Reserved.
 
+import logging
+from unittest import mock
 
+from coriolis import exception
+from coriolis.osmorphing import base
 from coriolis.osmorphing import rocky
 from coriolis.tests import test_base
 
 
 class BaseRockyLinuxMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
     """Test suite for the BaseRockyLinuxMorphingTools class."""
+
+    def setUp(self):
+        super(BaseRockyLinuxMorphingToolsTestCase, self).setUp()
+        self.detected_os_info = {
+            'os_type': 'linux',
+            'distribution_name': rocky.ROCKY_LINUX_DISTRO_IDENTIFIER,
+            'release_version': '8',
+            'friendly_release_name': mock.sentinel.friendly_release_name,
+        }
+        self.enable_repos = ['repo1', 'repo2']
+        self.morphing_tools = rocky.BaseRockyLinuxMorphingTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.os_root_dir, mock.sentinel.hypervisor,
+            mock.sentinel.event_manager, self.detected_os_info,
+            mock.sentinel.osmorphing_parameters)
 
     def test_check_os_supported(self):
         detected_os_info = {
@@ -29,3 +48,29 @@ class BaseRockyLinuxMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         )
 
         self.assertFalse(result)
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos(self, mock_exec_cmd_chroot):
+        self.morphing_tools.enable_repos(self.enable_repos)
+
+        mock_exec_cmd_chroot.assert_has_calls([
+            mock.call("dnf config-manager --set-enabled repo1"),
+            mock.call("dnf config-manager --set-enabled repo2"),
+        ])
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_empty(self, mock_exec_cmd_chroot):
+        self.morphing_tools.enable_repos([])
+
+        mock_exec_cmd_chroot.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test_enable_repos_with_exception(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = exception.CoriolisException()
+
+        with self.assertLogs(
+                'coriolis.osmorphing.rocky', level=logging.WARN):
+            self.morphing_tools.enable_repos(['repo1'])
+
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "dnf config-manager --set-enabled repo1")


### PR DESCRIPTION
This PR updates the logic so that during osmorphing, we'll no longer accept repository name substrings. The list of repository names defined by the providers must match exactly, otherwise a warning will be logged and the osmorphing workflow will continue without enabling the given repository.
 
If the instance uses custom repository names, the users may provide osmorphing scripts to enable necessary repositories.