### PR TITLE
Add support for the `SUSE/openSUSE 16 Cloud-Tools` repository URL

### DIFF
--- a/coriolis/osmorphing/suse.py
+++ b/coriolis/osmorphing/suse.py
@@ -22,6 +22,9 @@ OPENSUSE_TUMBLEWEED_VERSION_IDENTIFIER = (
     suse_detect.OPENSUSE_TUMBLEWEED_VERSION_IDENTIFIER)
 CLOUD_TOOLS_REPO_URI_FORMAT = (
     "https://download.opensuse.org/repositories/Cloud:/Tools/%s%s")
+CLOUD_TOOLS_REPO_URI_VERSION_ONLY_FORMAT = (
+    "https://download.opensuse.org/repositories/Cloud:/Tools/%s/")
+CLOUD_TOOLS_NEW_URL_MINIMUM_VERSION = 16
 
 
 class BaseSUSEMorphingTools(base.BaseLinuxOSMorphingTools):
@@ -156,15 +159,33 @@ class BaseSUSEMorphingTools(base.BaseLinuxOSMorphingTools):
                 (module, str(err))) from err
 
     def _add_cloud_tools_repo(self):
-        repo_suffix = ""
-        if self._version != (
-                OPENSUSE_TUMBLEWEED_VERSION_IDENTIFIER):
-            repo_suffix = "_%s" % self._version
-        repo = CLOUD_TOOLS_REPO_URI_FORMAT % (
-            self._detected_os_info[DETECTED_SUSE_RELEASE_FIELD_NAME].replace(
-                " ", "_"),
-            repo_suffix)
-        self._add_repo(repo, 'Cloud-Tools')
+        if self._version == OPENSUSE_TUMBLEWEED_VERSION_IDENTIFIER:
+            repo = CLOUD_TOOLS_REPO_URI_FORMAT % (
+                self._detected_os_info[
+                    DETECTED_SUSE_RELEASE_FIELD_NAME].replace(" ", "_"),
+                "")
+        elif self._version_supported_util(
+                self._version, minimum=CLOUD_TOOLS_NEW_URL_MINIMUM_VERSION):
+            repo = CLOUD_TOOLS_REPO_URI_VERSION_ONLY_FORMAT % self._version
+        else:
+            repo = CLOUD_TOOLS_REPO_URI_FORMAT % (
+                self._detected_os_info[
+                    DETECTED_SUSE_RELEASE_FIELD_NAME].replace(" ", "_"),
+                "_%s" % self._version)
+        try:
+            self._add_repo(repo, 'Cloud-Tools')
+        except Exception:
+            LOG.warning(
+                "Failed to add Cloud-Tools repo '%s'. If custom "
+                "repositories are configured on the target, this may be "
+                "safely ignored. Error was: %s", repo,
+                utils.get_exception_details())
+            self._event_manager.progress_update(
+                "Warning: failed to add Cloud-Tools repo '%s'. If the "
+                "required packages are available in already-configured "
+                "repositories, the migration may still succeed. If not, "
+                "please ensure the worker has internet access or "
+                "appropriate custom repositories are set up." % repo)
 
     def _get_repos(self):
         repos = {}

--- a/coriolis/tests/osmorphing/test_suse.py
+++ b/coriolis/tests/osmorphing/test_suse.py
@@ -285,6 +285,28 @@ class BaseSUSEMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         expected_repo = suse.CLOUD_TOOLS_REPO_URI_FORMAT % ('test_release', '')
         mock_add_repo.assert_called_once_with(expected_repo, 'Cloud-Tools')
 
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_add_repo')
+    def test_add_cloud_tools_repo_version_16(self, mock_add_repo):
+        self.morphing_tools._version = "16"
+
+        self.morphing_tools._add_cloud_tools_repo()
+
+        expected_repo = suse.CLOUD_TOOLS_REPO_URI_VERSION_ONLY_FORMAT % "16"
+        mock_add_repo.assert_called_once_with(expected_repo, 'Cloud-Tools')
+
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_add_repo')
+    def test_add_cloud_tools_repo_add_repo_failure(self, mock_add_repo):
+        mock_add_repo.side_effect = Exception("connection error")
+
+        with self.assertLogs(
+                'coriolis.osmorphing.suse', level=logging.WARNING):
+            self.morphing_tools._add_cloud_tools_repo()
+
+        expected_repo = suse.CLOUD_TOOLS_REPO_URI_FORMAT % (
+            'test_release', '_12')
+        mock_add_repo.assert_called_once_with(expected_repo, 'Cloud-Tools')
+        self.event_manager.progress_update.assert_called_once()
+
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     def test__get_repos(self, mock_exec_cmd_chroot):
         mock_exec_cmd_chroot.return_value = (


### PR DESCRIPTION
- In `openSUSE 16`, the `Cloud-Tools` repository path was changed and no longer includes the release name. This update introduces a version-only URL format for versions ≥ 16, while maintaining the legacy URL format for earlier releases;
- Also add `unit tests` covering this behavior