### PR TITLE
CI: bump Python test matrix and fix broken tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.14"]
         architecture: ["x64"]
 
     steps:

--- a/coriolis/api/v1/transfers.py
+++ b/coriolis/api/v1/transfers.py
@@ -70,8 +70,8 @@ class TransferController(api_wsgi.Controller):
             if scenario not in SUPPORTED_TRANSFER_SCENARIOS:
                 raise exc.HTTPBadRequest(
                     explanation=f"Unsupported Transfer creation scenario "
-                                f"'{scenario}', must be one of: "
-                                f"{SUPPORTED_TRANSFER_SCENARIOS}")
+                                f"'{scenario}', must be one of: "  # noqa
+                                f"{SUPPORTED_TRANSFER_SCENARIOS}")  # noqa
         else:
             scenario = constants.TRANSFER_SCENARIO_REPLICA
             LOG.warn(
@@ -317,8 +317,8 @@ class TransferController(api_wsgi.Controller):
         if scenario and scenario != transfer["scenario"]:
             raise exc.HTTPBadRequest(
                 explanation=f"Changing Transfer creation scenario is not "
-                            f"supported (original scenario is "
-                            f"{transfer['scenario']}, received '{scenario}')")
+                            f"supported (original scenario is "  # noqa
+                            f"{transfer['scenario']}, received '{scenario}')")  # noqa
 
         transfer_body = body['transfer']
         origin_endpoint_id = transfer_body.get('origin_endpoint_id', None)

--- a/coriolis/conductor/rpc/server.py
+++ b/coriolis/conductor/rpc/server.py
@@ -302,7 +302,7 @@ class ConductorServerEndpoint(object):
         if not reservation_type:
             raise exception.LicensingException(
                 message="Could not determine reservation type for transfer "
-                        f"'{action_id}' with scenario '{transfer.scenario}'.")
+                        f"'{action_id}' with scenario '{transfer.scenario}'.")  # noqa
         if not self._licensing_client:
             LOG.warn(
                 "Licensing client not instantiated. Skipping creation of "
@@ -1300,7 +1300,7 @@ class ConductorServerEndpoint(object):
         if transfer_scenario not in supported_scenarios:
             raise exception.InvalidInput(
                 message=f"Unsupported Transfer scenario '{transfer_scenario}'."
-                        f" Must be one of: {supported_scenarios}")
+                        f" Must be one of: {supported_scenarios}")  # noqa
 
         origin_endpoint = self.get_endpoint(ctxt, origin_endpoint_id)
         destination_endpoint = self.get_endpoint(

--- a/coriolis/db/api.py
+++ b/coriolis/db/api.py
@@ -902,7 +902,7 @@ def add_task_progress_update(
             f"Progress message for task '{task_id}' with ID '{task_event_id}'"
             f"is too long. Truncating before insertion. "
             f"Original message was: '{message}'")
-        message = f"{message[:max_msg_len-len('...')]}..."
+        message = f"{message[:max_msg_len-len('...')]}..."  # noqa
     task_progress_update.message = message
 
     task_progress_update.index = 0
@@ -936,7 +936,7 @@ def update_task_progress_update(
                 f"Progress message for task '{task_id}' with ID "
                 f"'{task_event_id}' is too long. Truncating before insertion."
                 f" Original message was: '{new_message}'")
-            new_message = f"{new_message[:max_msg_len-len('...')]}..."
+            new_message = f"{new_message[:max_msg_len-len('...')]}..."  # noqa
         task_progress_update.message = new_message
 
 

--- a/coriolis/osmorphing/windows.py
+++ b/coriolis/osmorphing/windows.py
@@ -341,7 +341,7 @@ class BaseWindowsMorphingTools(base.BaseOSMorphingTools):
             @({paths_string}) | ForEach-Object {{
                 Set-ItemProperty -Path $_ -Name 'Start' -Value {start_mode}
             }}
-            """,
+            """,  # noqa
             ignore_stdout=True)
 
     def _create_service(self, key_name, service_name, image_path,
@@ -667,8 +667,8 @@ class BaseWindowsMorphingTools(base.BaseOSMorphingTools):
             if diff:
                 LOG.warning(
                     f"The IP addresses {list(diff)} found on the source "
-                    f"VM's NIC were not found in the registry. These IPs will "
-                    f"be skipped in the static IP configuration process")
+                    "VM's NIC were not found in the registry. These IPs will "
+                    "be skipped in the static IP configuration process")
                 ip_matches = list(
                     set(reg_ip_addresses).intersection(set(nic_ips)))
                 if not ip_matches:

--- a/coriolis/tests/api/v1/test_endpoint_destination_minion_pool_options.py
+++ b/coriolis/tests/api/v1/test_endpoint_destination_minion_pool_options.py
@@ -57,7 +57,7 @@ class EndpointDestinationMinionPoolOptionsControllerTestCase(
 
         mock_context.can.assert_called_once_with(
             'migration:endpoints:list_destination_minion_pool_options')
-        mock_decode_base64_param.has_calls(expected_calls)
+        mock_decode_base64_param.assert_has_calls(expected_calls)
         (mock_get_endpoint_destination_minion_pool_options.
             assert_called_once_with)(
                 mock_context, endpoint_id,

--- a/coriolis/tests/api/v1/test_endpoint_destination_options.py
+++ b/coriolis/tests/api/v1/test_endpoint_destination_options.py
@@ -48,7 +48,7 @@ class EndpointDestinationOptionsControllerTestCase(
 
         mock_context.can.assert_called_once_with(
             'migration:endpoints:list_destination_options')
-        mock_decode_base64_param.has_calls(expected_calls)
+        mock_decode_base64_param.assert_has_calls(expected_calls)
         mock_get_endpoint_destination_options.assert_called_once_with(
             mock_context, endpoint_id,
             env=env,

--- a/coriolis/tests/api/v1/test_endpoint_instances.py
+++ b/coriolis/tests/api/v1/test_endpoint_instances.py
@@ -120,7 +120,7 @@ class EndpointInstanceControllerTestCase(test_base.CoriolisBaseTestCase):
 
         mock_context.can.assert_called_once_with(
             'migration:endpoints:get_instance')
-        mock_decode_base64_param.has_calls(expected_calls)
+        mock_decode_base64_param.assert_has_calls(expected_calls)
         mock_get_endpoint_instance.assert_called_once_with(
             mock_context, endpoint_id,
             env,

--- a/coriolis/tests/api/v1/test_endpoint_source_minion_pool_options.py
+++ b/coriolis/tests/api/v1/test_endpoint_source_minion_pool_options.py
@@ -52,7 +52,7 @@ class EndpointSourceMinionPoolOptionsControllerTestCase(
 
         mock_context.can.assert_called_once_with(
             'migration:endpoints:list_source_minion_pool_options')
-        mock_decode_base64_param.has_calls(expected_calls)
+        mock_decode_base64_param.assert_has_calls(expected_calls)
         (mock_get_endpoint_source_minion_pool_options.
             assert_called_once_with)(
                 mock_context, endpoint_id,

--- a/coriolis/tests/api/v1/test_endpoint_source_options.py
+++ b/coriolis/tests/api/v1/test_endpoint_source_options.py
@@ -48,7 +48,7 @@ class EndpointSourceOptionsControllerTestCase(test_base.CoriolisBaseTestCase):
 
         mock_context.can.assert_called_once_with(
             'migration:endpoints:list_source_options')
-        mock_decode_base64_param.has_calls(expected_calls)
+        mock_decode_base64_param.assert_has_calls(expected_calls)
         mock_get_endpoint_source_options.assert_called_once_with(
             mock_context, endpoint_id,
             env=env,

--- a/coriolis/tests/conductor/rpc/test_server.py
+++ b/coriolis/tests/conductor/rpc/test_server.py
@@ -5357,7 +5357,7 @@ class ConductorServerEndpointTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(db_api, "update_service")
     @mock.patch.object(rpc_worker_client.WorkerClient, "get_service_status")
-    @mock.patch.object(db_api, "get_service")
+    @mock.patch.object(db_api, "get_service", new_callable=mock.Mock)
     def test_refresh_service_status(
         self,
         mock_get_service,
@@ -5374,12 +5374,12 @@ class ConductorServerEndpointTestCase(test_base.CoriolisBaseTestCase):
             mock_get_service.return_value,
             result
         )
-        mock_get_service.has_calls([
+        mock_get_service.assert_has_calls([
             mock.call(
                 mock.sentinel.context,
                 mock.sentinel.service_id
-            ) * 2
-        ])
+            )
+        ] * 2)
         mock_get_service_status.assert_called_once_with(
             mock.sentinel.context)
         mock_update_service.assert_called_once_with(

--- a/coriolis/tests/tasks/test_replica_tasks.py
+++ b/coriolis/tests/tasks/test_replica_tasks.py
@@ -38,9 +38,10 @@ class ReplicaTasksTestCase(test_base.CoriolisBaseTestCase):
     def test__check_ensure_volumes_info_ordering(
             self, mock_sanitize, export_info, volumes_info,
             exception_expected, expected_result):
+        mock_sanitize.side_effect = lambda x: x
         expected_calls = [
-            mock.call.mock_sanitize({"volumes_info": volumes_info}),
-            mock.call.mock_sanitize({"volumes_info": expected_result}),
+            mock.call({"volumes_info": volumes_info}),
+            mock.call({"volumes_info": expected_result}),
         ]
         if exception_expected:
             self.assertRaises(
@@ -50,7 +51,7 @@ class ReplicaTasksTestCase(test_base.CoriolisBaseTestCase):
         else:
             result = replica_tasks._check_ensure_volumes_info_ordering(
                 export_info, volumes_info)
-            mock_sanitize.has_calls(expected_calls)
+            mock_sanitize.assert_has_calls(expected_calls)
             self.assertEqual(result, expected_result)
 
     @ddt.file_data("data/test_nic_ips_update.yml")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,8 +3,10 @@
 # process, which may cause wedges in the gate later.
 
 setuptools>=65.0.0,<82  # pkg_resources removed in 82; required by sqlalchemy-migrate
-hacking>=6.0.1,<=6.0.1 # Apache-2.0
+hacking>=7.0.0,<7.1.0 # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.2.1 # MIT
 oslotest>=3.8.0 # Apache-2.0
 stestr>=4.2.1 # Apache-2.0
+flake8>=7.0.0
+pyflakes>=3.2.0


### PR DESCRIPTION
Old Python versions do not support the modern type annotation syntax. It's time to update the test matrix. We'll drop 3.8 and 3.9, adding 3.12 and 3.14 instead.

Python 3.12 treats invalid mock has_calls as errors, we'll need to use the proper "assert_has_calls" method. This also uncovered a few broken assertions that need to be updated.

While at it, we're addressing flake8 errors. New flake8 versions cannot handle f strings properly, treating the string content as Python code. We'll add "noqa" comments where necessary.