### PR TITLE
removing leftover .decode() in netplan

### DIFF
--- a/coriolis/osmorphing/netpreserver/netplan.py
+++ b/coriolis/osmorphing/netpreserver/netplan.py
@@ -33,7 +33,7 @@ class NetplanNetPreserver(base.BaseNetPreserver):
             cfg_path = "%s/%s" % (self.netplan_base, cfg)
             try:
                 contents = yaml.safe_load(self.osmorphing_tool._read_file_sudo(
-                                          cfg_path).decode())
+                                          cfg_path))
                 LOG.info("Parsing netplan configuration '%s'", cfg_path)
                 ifaces = contents.get('network', {}).get('ethernets', {})
                 for iface, net_cfg in ifaces.items():


### PR DESCRIPTION
Removing leftover .decode() which was already moved in the main method that executes commands via ssh