### PR TITLE
Fix a flaky issue with task percentage not stored in DB

### DIFF
--- a/coriolis/conductor/rpc/client.py
+++ b/coriolis/conductor/rpc/client.py
@@ -293,8 +293,17 @@ class ConductorClient(rpc.BaseRPCClient):
 
     def update_task_progress_update(
             self, ctxt, task_id, progress_update_index, new_current_step,
-            new_total_steps=None, new_message=None):
-        self._cast(
+            new_total_steps=None, new_message=None, sync=False):
+        # Use _call on the last step to make sure the DB is updated
+        # and the UI is showing the correct progress.
+        # Intermediate steps use cast to avoid blocking on every tick.
+        if sync:
+            return self._call(
+                ctxt, 'update_task_progress_update', task_id=task_id,
+                progress_update_index=progress_update_index,
+                new_current_step=new_current_step,
+                new_total_steps=new_total_steps, new_message=new_message)
+        return self._cast(
             ctxt, 'update_task_progress_update', task_id=task_id,
             progress_update_index=progress_update_index,
             new_current_step=new_current_step,
@@ -468,13 +477,14 @@ class ConductorTaskRpcEventHandler(events.BaseEventHandler):
 
     def update_progress_update(
             self, update_identifier, new_current_step,
-            new_total_steps=None, new_message=None):
+            new_total_steps=None, new_message=None, sync=False):
         LOG.info(
             "Updating progress update '%s' for task '%s' with new step %s",
             update_identifier, self._task_id, new_current_step)
         self._rpc_conductor_client.update_task_progress_update(
             self._ctxt, self._task_id, update_identifier, new_current_step,
-            new_total_steps=new_total_steps, new_message=new_message)
+            new_total_steps=new_total_steps, new_message=new_message,
+            sync=sync)
 
     def add_event(self, message, level=constants.TASK_EVENT_INFO):
         self._rpc_conductor_client.add_task_event(

--- a/coriolis/db/api.py
+++ b/coriolis/db/api.py
@@ -925,6 +925,21 @@ def update_task_progress_update(
             "Could not find progress update for task with ID '%s' and "
             "index %s in the DB for updating." % (task_id, update_index))
 
+    # Quick progress updates may be processed out of order.
+    # We're trying to mitigate this by checking the current step.
+    #
+    # TODO(ffulga): the current approach is still prone to race conditions
+    # since `task_progress_update.current_step` may be out of date.
+    # The safest approach would be to use a db-level `compare-and-update`
+    # sql operation.
+    if new_current_step < task_progress_update.current_step:
+        LOG.debug(
+            "Ignoring out-of-order progress update for task '%s' "
+            "index %s: new_current_step=%s is behind stored current_step=%s",
+            task_id, update_index, new_current_step,
+            task_progress_update.current_step)
+        return
+
     task_progress_update.current_step = new_current_step
     if new_total_steps is not None:
         task_progress_update.total_steps = new_total_steps

--- a/coriolis/events.py
+++ b/coriolis/events.py
@@ -76,9 +76,12 @@ class EventManager(object, with_metaclass(abc.ABCMeta)):
             perc = int(new_current_step * 100 // perc_step.total_steps)
 
         if self._call_event_handler and perc > perc_step.last_perc:
+            sync_final = (
+                perc_step.total_steps > 0 and
+                new_current_step >= perc_step.total_steps)
             self._call_event_handler(
                 'update_progress_update', step.progress_update_id,
-                new_current_step)
+                new_current_step, sync=sync_final)
             perc_id = copy.copy(step.progress_update_id)
             total_steps = perc_step.total_steps
             del self._perc_steps[step.progress_update_id]
@@ -114,7 +117,7 @@ class BaseEventHandler(object, with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
     def update_progress_update(
             self, update_identifier, new_current_step,
-            new_total_steps=None, new_message=None):
+            new_total_steps=None, new_message=None, sync=False):
         pass
 
     @classmethod

--- a/coriolis/minion_manager/rpc/client.py
+++ b/coriolis/minion_manager/rpc/client.py
@@ -205,7 +205,7 @@ class MinionManagerPoolRpcEventHandler(events.BaseEventHandler):
 
     def update_progress_update(
             self, update_identifier, new_current_step,
-            new_total_steps=None, new_message=None):
+            new_total_steps=None, new_message=None, sync=False):
         LOG.info(
             "Updating progress update '%s' for pool '%s' with new step %s",
             update_identifier, self._pool_id, new_current_step)

--- a/coriolis/tests/conductor/rpc/test_client.py
+++ b/coriolis/tests/conductor/rpc/test_client.py
@@ -291,8 +291,23 @@ class ConductorClientTestCase(test_base.CoriolisRPCClientTestCase):
             "new_total_steps": None,
             "new_message": None
         }
-        self._test(self.client.update_task_progress_update, args,
-                   rpc_op='_cast')
+        self._test(
+            self.client.update_task_progress_update, args, rpc_op='_cast')
+
+    def test_update_task_progress_update_sync_final(self):
+        args = {
+            "task_id": "mock_task_id",
+            "progress_update_index": "mock_progress_update_index",
+            "new_current_step": "mock_new_current_step",
+            "new_total_steps": None,
+            "new_message": None,
+        }
+        with mock.patch.object(self.client, '_call') as op_mock:
+            ctxt = mock.sentinel.ctxt
+            self.client.update_task_progress_update(
+                ctxt, sync=True, **args)
+            op_mock.assert_called_once_with(
+                ctxt, 'update_task_progress_update', **args)
 
     def test_create_transfer_schedule(self):
         args = {
@@ -533,7 +548,8 @@ class ConductorTaskRpcEventHandlerTestCase(test_base.CoriolisBaseTestCase):
             update_identifier,
             new_current_step,
             new_total_steps=new_total_steps,
-            new_message=new_message
+            new_message=new_message,
+            sync=False,
         )
 
     @mock.patch.object(client.ConductorClient, 'add_task_event')

--- a/coriolis/tests/test_events.py
+++ b/coriolis/tests/test_events.py
@@ -110,6 +110,19 @@ class EventManagerTestCase(test_base.CoriolisBaseTestCase):
             mock.sentinel.progress_update_id: events._PercStepData(
                 mock.sentinel.progress_update_id, 60, 0, 100)}
         self.assertEqual(self.event_manager._perc_steps, expected_perc_steps)
+        self.mock_event_handler.update_progress_update.assert_called_once_with(
+            mock.sentinel.progress_update_id, 60, sync=False)
+
+    def test_set_percentage_step_sync_final_update(self):
+        perc_step_data = events._PercStepData(
+            mock.sentinel.progress_update_id, 90, 0, 100)
+        self.event_manager._perc_steps[
+            mock.sentinel.progress_update_id] = perc_step_data
+
+        self.event_manager.set_percentage_step(perc_step_data, 100)
+
+        self.mock_event_handler.update_progress_update.assert_called_once_with(
+            mock.sentinel.progress_update_id, 100, sync=True)
 
     def test_set_percentage_step_no_perc_step(self):
         self.event_manager.set_percentage_step(


### PR DESCRIPTION
It seems like there is a flaky issue with the percentage for Replicate Disks.
The final steps for replication are not stored in the DB and the UI doesn't display the 100% for disk replication. The worker reaches the 100%, but the 100% is never stored in the DB.

This issue seems to come from the `self._cast` from `update_task_progress_update`.

NOTE: Changing it to `_call` seems to fix the issue, but the whole issue is hard to replicate.