### PR TITLE
integration: Move mock patches to class setUp

### DIFF
--- a/coriolis/tests/integration/base.py
+++ b/coriolis/tests/integration/base.py
@@ -52,6 +52,13 @@ class CoriolisIntegrationTestBase(test_base.CoriolisBaseTestCase):
         cls._imp_platform = cls._harness.imp_provider_platform
         cls._client = cls.get_client()
 
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch("psutil.Process.send_signal")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     # Helpers for subclasses
     @classmethod
     def get_client(cls):

--- a/coriolis/tests/integration/harness.py
+++ b/coriolis/tests/integration/harness.py
@@ -262,9 +262,6 @@ class _IntegrationHarness:
         coriolis_utils.setup_logging()
         test_utils.init_scsi_debug()
 
-        self._send_signal_patcher = mock.patch("psutil.Process.send_signal")
-        self._send_signal_patcher.start()
-
         # Policy enforcer: reset so it re-reads the new CONF (no policy file).
         policy_module.reset()
 
@@ -417,8 +414,6 @@ class _IntegrationHarness:
 
     def _teardown(self):
         LOG.info("Teardown initiated.")
-
-        self._send_signal_patcher.stop()
 
         try:
             coriolis_utils.exec_process(

--- a/coriolis/tests/integration/test_failure_recovery.py
+++ b/coriolis/tests/integration/test_failure_recovery.py
@@ -13,7 +13,6 @@ exception, triggers a transfer execution, and asserts that:
 Must be run as root; requires the scsi_debug kernel module.
 """
 
-import unittest
 from unittest import mock
 
 from coriolis.tests.integration import base
@@ -25,10 +24,6 @@ class TransferFailureIntegrationTest(base.ReplicaIntegrationTestBase):
 
     def test_error_status_on_provider_failure(self):
         """Execution reaches ERROR when target resource deployment fails."""
-        raise unittest.SkipTest(
-            "Currently skipped, causes the test process to be killed. "
-            "Re-enable the test once we switch to external Coriolis services.")
-
         injected_error = Exception("injected target resource failure")
 
         with mock.patch.object(


### PR DESCRIPTION
`oslotest`'s base class may add `mock.patch.stopall` to the cleanup (`super().addCleanup(mock.patch.stopall)`), which means that the patches we have made in the harness will be undone when the second test runs.

This may mean that `psutil.Process.send_signal` becomes unpatched, and SIGINT will be sent to the test runners, typically on cancelation tests.