### PR TITLE
backup writer: update the list of lvm udev files to be deleted

### DIFF
--- a/coriolis/providers/backup_writers.py
+++ b/coriolis/providers/backup_writers.py
@@ -112,7 +112,10 @@ def _disable_lvm_metad_udev_rule(ssh):
     """
     rule_paths = [
         "/lib/udev/rules.d/69-lvm-metad.rules",
-        "/lib/udev/rules.d/69-dm-lvm.rules"]
+        "/lib/udev/rules.d/69-dm-lvm.rules",
+        "/lib/udev/rules.d/69-lvm.rules",
+        "/lib/udev/rules.d/56-lvm.rules",
+    ]
     for path in rule_paths:
         if utils.test_ssh_path(ssh, path):
             utils.exec_ssh_cmd(ssh, "sudo rm %s" % path, get_pty=True)

--- a/coriolis/tests/providers/test_backup_writers.py
+++ b/coriolis/tests/providers/test_backup_writers.py
@@ -49,21 +49,24 @@ class BackupWritersTestCase(test_base.CoriolisBaseTestCase):
     @mock.patch('coriolis.utils.exec_ssh_cmd')
     def test__disable_lvm_metad_udev_rule(self, mock_exec_ssh_cmd,
                                           mock_test_ssh_path):
-        rule_path = ["/lib/udev/rules.d/69-lvm-metad.rules",
-                     "/lib/udev/rules.d/69-dm-lvm.rules"]
+        rule_paths = [
+            "/lib/udev/rules.d/69-lvm-metad.rules",
+            "/lib/udev/rules.d/69-dm-lvm.rules",
+            "/lib/udev/rules.d/69-lvm.rules",
+            "/lib/udev/rules.d/56-lvm.rules",
+        ]
         mock_test_ssh_path.return_value = True
 
         backup_writers._disable_lvm_metad_udev_rule(self.mock_ssh)
 
         mock_test_ssh_path.assert_has_calls(
-            [mock.call(self.mock_ssh, rule_path[0]),
-             mock.call(self.mock_ssh, rule_path[1])])
+            [mock.call(self.mock_ssh, rule_path)
+             for rule_path in rule_paths])
 
         expected_calls = [
-            mock.call(self.mock_ssh, 'sudo rm %s' % rule_path[0],
-                      get_pty=True),
-            mock.call(self.mock_ssh, 'sudo rm %s' % rule_path[1],
-                      get_pty=True)]
+            mock.call(self.mock_ssh, 'sudo rm %s' % rule_path,
+                      get_pty=True)
+            for rule_path in rule_paths]
         mock_exec_ssh_cmd.assert_has_calls(expected_calls)
 
     def test__check_deserialize_key(self):


### PR DESCRIPTION
The backup writer initialization will disable LVM udev rules used by the minion worker. The migrated replica disks may contain LVM volumes and we'll no longer be able to modify them while being used by LVM.

We'll need to update the list of udev files to acommodate Ubuntu 24.04 workers.