### PR TITLE
integration: Various test fixes and cleanup

### DIFF
--- a/coriolis/tests/integration/README.md
+++ b/coriolis/tests/integration/README.md
@@ -1,28 +1,32 @@
 # Coriolis Integration Tests
 
 Integration tests that exercise the full Coriolis service stack
-(conductor, scheduler, worker, and REST API) in a single process,
-using an in-memory transport and a temporary SQLite database.
-No RabbitMQ, Keystone, Barbican, or external cloud is required.
+(conductor, scheduler, worker, transfer-cron, deployer-manager,
+minion-manager, and REST API) in a single process, using an in-memory
+transport, and a MariaDB database running in Docker.
+No RabbitMQ, Keystone, or Barbican is required.
 
 ## How it works
 
 The test harness (`harness.py`) performs a one-time setup per process:
 
-1. Creates a temporary working directory and SQLite database.
-2. Overrides `oslo.config` so all services use `fake://` messaging and
-   the temporary DB.
-3. Runs `db_sync` to apply all schema migrations.
-4. Starts conductor, scheduler, and worker inside the test process. The
-   worker runs task code inline (not in subprocesses) so that in-process
-   RPC calls reach the conductor.
-5. Serves the REST API on a random local port, with Keystone auth replaced by
-   a no-op middleware that injects a fixed admin context.
-6. Injects a fake block-device provider (`providers/test_provider/`)
-   that uses `scsi_debug` virtual disks as source and destination storage.
+1. Creates a temporary working directory and generates an SSH key pair.
+2. Starts a `mariadb:10-jammy` Docker container on port 13306 as the
+   database backend.
+3. Overrides `oslo.config` so all services use `fake://` messaging and
+   the Docker database.
+4. Runs `db_sync` to apply all schema migrations.
+5. Starts conductor, scheduler, worker, transfer-cron, deployer-manager,
+   and minion-manager inside the test process. The worker runs task code
+   as threads (not subprocesses) so that in-process RPC calls reach the
+   conductor over the `fake://` transport.
+6. Serves the REST API via cheroot on a random local port, with Keystone
+   auth replaced by a no-op middleware that injects a fixed admin context.
+7. Registers the built-in `test_provider` as both the export and import
+   provider.
 
-Teardown (registered with `atexit`) stops all services, removes the
-working directory, and unloads the `scsi_debug` kernel module.
+Teardown (registered with `atexit`) stops all services, removes the Docker
+container, removes the working directory, and unloads `scsi_debug`.
 
 ## Prerequisites
 
@@ -34,12 +38,27 @@ working directory, and unloads the `scsi_debug` kernel module.
 | `lsblk`, `udevadm` | Device discovery after hot-adding a `scsi_debug` host |
 | `dd`, `sync`, `cmp` | Test-pattern writes and device comparison |
 | `modprobe` | Loading and unloading `scsi_debug` |
+| `docker` | MariaDB database container; data-minion container image |
+| `ssh-keygen` | Generates the ephemeral SSH key pair used by the test provider |
 
 On Ubuntu / Debian:
 ```bash
 sudo apt-get install util-linux kmod
 # scsi_debug ships with the standard kernel; no extra package is needed
 ```
+
+### Docker image - data-minion
+
+`ReplicaIntegrationTestBase` and its subclasses require a pre-built
+Docker image named `coriolis-data-minion:test`:
+
+```bash
+docker build -t coriolis-data-minion:test \
+    coriolis/tests/integration/dockerfiles/data-minion/
+```
+
+Tests in classes that extend `ReplicaIntegrationTestBase` are skipped
+automatically when this image is not found locally.
 
 ### Python dependencies
 
@@ -73,7 +92,7 @@ sudo tox -e integration
 sudo tox -e integration -- --no-discover coriolis/tests/integration/test_smoke.py
 
 # A specific test class or method
-sudo tox -e integration -- --no-discover coriolis.tests.integration.test_transfer.ReplicaTransferIntegrationTest.test_incremental_replica_transfer
+sudo tox -e integration -- --no-discover coriolis.tests.integration.transfers.test_transfer.ReplicaTransferIntegrationTest.test_incremental_replica_transfer
 ```
 
 > `sudo` is required because `tox` itself must run as root so that the
@@ -81,29 +100,80 @@ sudo tox -e integration -- --no-discover coriolis.tests.integration.test_transfe
 
 ## Test modules
 
-| Module | Base class | Description |
-|--------|-----------|-------------|
-| `test_smoke.py` | `CoriolisIntegrationTestBase` | Verifies API reachability and basic endpoint / transfer CRUD. No block devices needed. |
-| `test_transfer.py` | `ReplicaIntegrationTestBase` | Full replica transfer: initial full sync then incremental after a source mutation; asserts byte-level device equality. |
-| `test_deployment.py` | `ReplicaIntegrationTestBase` | Runs a replica execution, then creates a deployment from it and asserts it reaches `COMPLETED`. |
-| `test_failure_recovery.py` | `ReplicaIntegrationTestBase` | Injects an exception into the provider's `deploy_replica_target_resources`; asserts that the execution reaches `ERROR`. |
+### No block devices (extend `CoriolisIntegrationTestBase`)
+
+| Module | Description |
+|--------|-------------|
+| `test_smoke.py` | Verifies API reachability and basic endpoint / transfer CRUD. |
+| `test_endpoints.py` | Endpoint capability APIs: validate connection, networks, storage, instances. |
+| `test_pagination.py` | Transfer, execution, and deployment list pagination. |
+| `test_minion_pools.py` | Minion pool CRUD and allocate / deallocate lifecycle. |
+| `management/test_diagnostics.py` | `diagnostics.get()` API. |
+| `management/test_providers.py` | `providers.list()` and `providers.schemas_list()`. |
+| `management/test_region.py` | Region CRUD. |
+| `management/test_service.py` | Service registration and CRUD. |
+
+### Block devices required (extend `ReplicaIntegrationTestBase`)
+
+| Module | Description |
+|--------|-------------|
+| `transfers/test_transfer.py` | Full replica transfer: initial sync, incremental after source mutation, byte-level device equality. |
+| `transfers/test_executions.py` | Execution CRUD, `shutdown_instances`, `auto_deploy`. |
+| `transfers/test_schedules.py` | Schedule CRUD and triggered execution. |
+| `deployments/test_deployment.py` | Create deployment from replica, CRUD, `clone_disks=False`, cancel. |
+| `deployments/test_osmorphing.py` | Deployment with `skip_os_morphing=False`; writes an Ubuntu 24.04 image to the source device and asserts a package is installed by the OS morphing step. |
+| `test_failure_recovery.py` | Injects an exception into `deploy_replica_target_resources`; asserts the execution reaches `ERROR`. |
+
+## Base classes
+
+| Class | Module | Use when |
+|-------|--------|----------|
+| `CoriolisIntegrationTestBase` | `base.py` | API-level tests; no block devices needed. |
+| `ReplicaIntegrationTestBase` | `base.py` | Tests that exercise the transfer / deployment pipeline with real disk I/O via `scsi_debug`. Requires the `coriolis-data-minion:test` Docker image. |
+| `MinionPoolTestBase` | `base.py` | Like `CoriolisIntegrationTestBase`; skips when the import provider does not advertise minion-pool support. |
+| `MinionPoolReplicaTestBase` | `base.py` | Like `ReplicaIntegrationTestBase` with a pre-allocated minion pool; also asserts the pool and its machines return to a healthy state after each execution. |
+
+## Assertion helpers (available on `ReplicaIntegrationTestBase`)
+
+- `assertExecutionCompleted(execution_id)` - polls until the execution reaches `COMPLETED`.
+- `assertExecutionErrored(execution_id)` - polls until the execution reaches `ERROR` or `DEADLOCKED`.
+- `assertDeploymentCompleted(deployment_id)` - polls until the deployment's last execution status is `COMPLETED`.
+- `wait_for_execution(execution_id)` - blocks until any terminal status; returns the ORM object.
+- `wait_for_deployment(deployment_id)` - blocks until any terminal status; returns the ORM object.
 
 ## Directory structure
 
 ```
 integration/
-├── base.py             # base test classes
-├── harness.py          # _IntegrationHarness singleton
-├── utils.py            # scsi_debug helpers, device I/O utilities
+├── base.py                     # base test classes
+├── harness.py                  # _IntegrationHarness singleton
+├── utils.py                    # scsi_debug helpers, device I/O, OS image utilities
 ├── test_smoke.py
-├── test_transfer.py
-├── test_deployment.py
+├── test_endpoints.py
 ├── test_failure_recovery.py
-└── providers/
-    └── test_provider/  # Fake cloud provider backed by scsi_debug devices
-        ├── __init__.py
-        ├── exp.py      # Export provider
-        └── imp.py      # Import provider
+├── test_minion_pools.py
+├── test_pagination.py
+├── transfers/
+│   ├── test_transfer.py
+│   ├── test_executions.py
+│   └── test_schedules.py
+├── deployments/
+│   ├── test_deployment.py
+│   └── test_osmorphing.py
+├── management/
+│   ├── test_diagnostics.py
+│   ├── test_providers.py
+│   ├── test_region.py
+│   └── test_service.py
+├── test_provider/              # built-in fake cloud provider (scsi_debug backed)
+│   ├── __init__.py
+│   ├── exp.py                  # Export provider
+│   ├── imp.py                  # Import provider
+│   └── osmorphing/             # OS morphing tools for the test provider
+│       └── ubuntu.py
+└── dockerfiles/
+    └── data-minion/            # Dockerfile for the worker SSH target container
+        └── Dockerfile
 ```
 
 ## Adding new tests
@@ -111,8 +181,11 @@ integration/
 1. Extend `CoriolisIntegrationTestBase` for API-level tests that do not
    need block devices, or `ReplicaIntegrationTestBase` for tests that
    exercise the transfer / deployment pipeline with real disk I/O.
-2. Use `self.assertExecutionCompleted()`, `self.assertExecutionErrored()`,
-   and `self.assertDeploymentCompleted()` to wait for and assert on
+2. Place the new module in the appropriate subdirectory (`transfers/`,
+   `deployments/`, `management/`) or at the top level for cross-cutting
+   concerns.
+3. Use `assertExecutionCompleted()`, `assertExecutionErrored()`,
+   and `assertDeploymentCompleted()` to wait for and assert on
    async operation outcomes.
-3. Do not start the harness manually; `setUpClass` in the base class
+4. Do not start the harness manually; `setUpClass` in the base class
    calls `_IntegrationHarness.get()`, which is idempotent.

--- a/coriolis/tests/integration/base.py
+++ b/coriolis/tests/integration/base.py
@@ -329,6 +329,31 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
             transfer_id, shutdown_instances=False)
         self.assertExecutionCompleted(execution.id, timeout=timeout)
 
+    def _cleanup_execution(self, transfer_id, execution_id):
+        """Cancel a running execution if needed, then delete it.
+
+        Cancels the transfer execution if it has not yet reached a terminal
+        state, waits up to 60s for it to finish, then deletes it.
+
+        This avoids the 400 HTTP "cannot delete a RUNNING execution" error that
+        occurs when an execution is still in-flight at cleanup time, which can
+        happen with slow providers when a test fails or times out before the
+        execution completes.
+        """
+        ctxt = self._get_db_context()
+        try:
+            execution = db_api.get_tasks_execution(ctxt, execution_id)
+        except exception.NotFound:
+            LOG.info(
+                "Task execution '%s' not found. Skip cleanup.", execution_id)
+            return
+
+        if execution.status not in constants.FINALIZED_EXECUTION_STATUSES:
+            self._client.transfer_executions.cancel(transfer_id, execution_id)
+            self.wait_for_execution(execution_id, timeout=60)
+
+        self._client.transfer_executions.delete(transfer_id, execution_id)
+
     def wait_for_execution(self, execution_id, timeout=300,
                            desired_statuses=None):
         """Block until *execution_id* reaches a terminal state.
@@ -350,9 +375,9 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
                 return execution
             time.sleep(1)
         self.fail(
-            "Execution %s did not reach one of the states %r within %ds"
+            "Execution %s did not reach one of the states %r within %ds "
             "(last status: %s)"
-            % (execution_id, timeout, desired_statuses, execution.status)
+            % (execution_id, desired_statuses, timeout, execution.status)
         )
 
     def assertExecutionCompleted(self, execution_id, timeout=300):
@@ -389,6 +414,31 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
             % (execution_id, execution.status),
         )
 
+    def _cleanup_deployment(self, deployment_id):
+        """Cancel a running deployment if needed, then delete it.
+
+        Cancels the deployment if it has not yet reached a terminal state,
+        waits up to 60s for it to finish, then deletes it.
+
+        This avoids the 400 HTTP "cannot delete a RUNNING deployment" error
+        that occurs when a deployment is still in-flight at cleanup time, which
+        can happen with slow providers when a test fails or times out before
+        the deployment completes.
+        """
+        ctxt = self._get_db_context()
+        deployment = db_api.get_deployment(ctxt, deployment_id)
+        if deployment is None:
+            LOG.info(
+                "Deployment '%s' not found. Skip cleanup.", deployment_id)
+            return
+
+        if deployment.last_execution_status in (
+                constants.ACTIVE_EXECUTION_STATUSES):
+            self._client.deployments.cancel(deployment_id)
+            self.wait_for_deployment(deployment_id, timeout=60)
+
+        self._client.deployments.delete(deployment_id)
+
     def wait_for_deployment(self, deployment_id, timeout=300,
                             desired_statuses=None):
         """Block until *deployment_id* reaches any terminal state.
@@ -407,8 +457,10 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
                 return deployment
             time.sleep(1)
         self.fail(
-            "Deployment %s did not reach one of the states %r within %ds"
-            % (deployment_id, desired_statuses, timeout)
+            "Deployment %s did not reach one of the states %r within %ds "
+            "(last status: %s)"
+            % (deployment_id, desired_statuses, timeout,
+               deployment.last_execution_status)
         )
 
     def assertDeploymentCompleted(self, deployment_id, timeout=300):

--- a/coriolis/tests/integration/base.py
+++ b/coriolis/tests/integration/base.py
@@ -29,6 +29,7 @@ import oslo_messaging as messaging
 from coriolis import constants
 from coriolis import context
 from coriolis.db import api as db_api
+from coriolis import exception
 from coriolis.providers import factory as providers_factory
 from coriolis.tests.integration import harness
 from coriolis.tests.integration import utils as test_utils
@@ -64,7 +65,11 @@ class CoriolisIntegrationTestBase(test_base.CoriolisBaseTestCase):
         cls._lock_path = cls._harness.lock_path
         cls._api_port = cls._harness.api_port
         cls._exp_platform = cls._harness.exp_provider_platform
+        cls._exp_conn_info = cls._harness.exp_conn_info
+
         cls._imp_platform = cls._harness.imp_provider_platform
+        cls._imp_conn_info = cls._harness.imp_conn_info
+
         cls._client = cls.get_client()
 
     def setUp(self):
@@ -202,7 +207,7 @@ class CoriolisIntegrationTestBase(test_base.CoriolisBaseTestCase):
             time.sleep(1)
         pool = db_api.get_minion_pool(ctxt, pool_id)
         last = pool.status if pool else "not found"
-        cls.fail(
+        raise AssertionError(
             "Pool %s did not reach one of %r within %ds (last: %s)"
             % (pool_id, terminal_statuses, timeout, last)
         )
@@ -252,20 +257,14 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
             name="test-src",
             endpoint_type=cls._exp_platform,
             description="integration source endpoint",
-            connection_info={
-                "pkey_path": cls._harness.ssh_key_path,
-                "role": "source",
-            },
+            connection_info=cls._exp_conn_info,
         )
 
         cls._dst_endpoint = cls._create_endpoint(
             name="test-dest",
             endpoint_type=cls._imp_platform,
             description="integration destination endpoint",
-            connection_info={
-                "pkey_path": cls._harness.ssh_key_path,
-                "role": "destination",
-            },
+            connection_info=cls._imp_conn_info,
         )
 
         # Create minion pool if needed.
@@ -277,7 +276,7 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
 
             pool_obj = cls._wait_for_pool(pool.id, MINION_ALLOCATED_TERMINAL)
             if pool_obj.status != constants.MINION_POOL_STATUS_ALLOCATED:
-                cls.fail(
+                raise AssertionError(
                     "Pool did not reach ALLOCATED (got %s)" % pool_obj.status,
                 )
 
@@ -300,10 +299,13 @@ class ReplicaIntegrationTestBase(CoriolisIntegrationTestBase):
         test_utils.write_test_pattern(self._src_device, 8192)
 
         # Create transfer replica.
+        # Use basename as instance name; real VM names do not contain slashes,
+        # and some providers use the name as is in resource indentifiers.
+        instance_name = os.path.basename(self._src_device)
         self._transfer = self._create_transfer(
             self._src_endpoint.id,
             self._dst_endpoint.id,
-            instances=[self._src_device],
+            instances=[instance_name],
             destination_minion_pool_id=self._pool_id,
             source_environment={"block_device_path": self._src_device},
             destination_environment={"devices": [self._dst_device]},
@@ -498,15 +500,19 @@ class MinionPoolTestBase(CoriolisIntegrationTestBase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
-
+        # Check before super(), so that ReplicaIntegrationTestBase.setUpClass
+        # does not attempt pool creation against a provider that doesn't
+        # support it.
+        h = harness._IntegrationHarness.get()
         available = providers_factory.get_available_providers()
-        imp_types = available.get(cls._imp_platform, {}).get("types", [])
+        imp_types = available.get(h.imp_provider_platform, {}).get("types", [])
         if constants.PROVIDER_TYPE_DESTINATION_MINION_POOL not in imp_types:
             raise unittest.SkipTest(
                 "Import provider '%s' does not support minion pools"
-                % cls._imp_platform
+                % h.imp_provider_platform
             )
+
+        super().setUpClass()
 
 
 class MinionPoolReplicaTestBase(

--- a/coriolis/tests/integration/deployments/test_deployment.py
+++ b/coriolis/tests/integration/deployments/test_deployment.py
@@ -26,8 +26,7 @@ class ReplicaDeploymentIntegrationTest(base.ReplicaIntegrationTestBase):
 
         deployment = self._client.deployments.create_from_transfer(
             self._transfer.id, **kwargs)
-        self.addCleanup(
-            self._ignoreExc(self._client.deployments.delete), deployment.id)
+        self.addCleanup(self._cleanup_deployment, deployment.id)
 
         return deployment
 

--- a/coriolis/tests/integration/deployments/test_osmorphing.py
+++ b/coriolis/tests/integration/deployments/test_osmorphing.py
@@ -33,7 +33,7 @@ class OsMorphingDeploymentTest(integration_base.ReplicaIntegrationTestBase):
             self._transfer.id,
             skip_os_morphing=False,
         )
-        self.addCleanup(self._client.deployments.delete, deployment.id)
+        self.addCleanup(self._cleanup_deployment, deployment.id)
 
         self.assertDeploymentCompleted(deployment.id)
         self.assertTrue(

--- a/coriolis/tests/integration/harness.py
+++ b/coriolis/tests/integration/harness.py
@@ -76,11 +76,11 @@ _TEST_IMPORT_PROVIDER = (
 _TEST_PROJECT_ID = 'integration-project'
 
 
-def _provider_platform(dotted_path):
-    """Return the ``platform`` attribute of the class at *dotted_path*."""
+def _get_provider(dotted_path):
+    """Return the class at the *dotted_path*."""
     module_path, class_name = dotted_path.rsplit('.', 1)
     cls = getattr(importlib.import_module(module_path), class_name)
-    return cls.platform
+    return cls
 
 
 class DaemonCherootWorker(cheroot_threadpool.WorkerThread):
@@ -302,8 +302,19 @@ class _IntegrationHarness:
         # Policy enforcer: reset so it re-reads the new CONF (no policy file).
         policy_module.reset()
 
-        self.exp_provider_platform = _provider_platform(_TEST_EXPORT_PROVIDER)
-        self.imp_provider_platform = _provider_platform(_TEST_IMPORT_PROVIDER)
+        self.exp_provider_class = _get_provider(_TEST_EXPORT_PROVIDER)
+        self.exp_provider_platform = self.exp_provider_class.platform
+        self.exp_conn_info = {
+            "pkey_path": self.ssh_key_path,
+            "role": "source",
+        }
+
+        self.imp_provider_class = _get_provider(_TEST_IMPORT_PROVIDER)
+        self.imp_provider_platform = self.imp_provider_class.platform
+        self.imp_conn_info = {
+            "pkey_path": self.ssh_key_path,
+            "role": "destination",
+        }
 
         self._wsgi_server = None
         self._wsgi_server_thread = None

--- a/coriolis/tests/integration/test_endpoints.py
+++ b/coriolis/tests/integration/test_endpoints.py
@@ -23,16 +23,12 @@ class EndpointCapabilitiesTest(base.CoriolisIntegrationTestBase):
         self._src_endpoint = self._create_endpoint(
             name="cap-src",
             endpoint_type=self._exp_platform,
-            connection_info={
-                "pkey_path": self._harness.ssh_key_path,
-            },
+            connection_info=self._exp_conn_info,
         )
         self._dst_endpoint = self._create_endpoint(
             name="cap-dest",
             endpoint_type=self._imp_platform,
-            connection_info={
-                "pkey_path": self._harness.ssh_key_path,
-            },
+            connection_info=self._imp_conn_info,
         )
 
     def test_validate_connection(self):

--- a/coriolis/tests/integration/test_failure_recovery.py
+++ b/coriolis/tests/integration/test_failure_recovery.py
@@ -4,8 +4,8 @@
 """
 Integration test for failure handling and cleanup.
 
-Patches TestImportProvider.deploy_replica_target_resources to raise an
-exception, triggers a transfer execution, and asserts that:
+Patches the active import provider's deploy_replica_target_resources to raise
+an exception, triggers a transfer execution, and asserts that:
   1. The execution reaches ERROR status.
   2. Cleanup tasks (delete_replica_source_resources) ran so the replicator
      process is no longer alive.
@@ -16,7 +16,6 @@ Must be run as root; requires the scsi_debug kernel module.
 from unittest import mock
 
 from coriolis.tests.integration import base
-from coriolis.tests.integration.test_provider import imp
 
 
 class TransferFailureIntegrationTest(base.ReplicaIntegrationTestBase):
@@ -27,7 +26,7 @@ class TransferFailureIntegrationTest(base.ReplicaIntegrationTestBase):
         injected_error = Exception("injected target resource failure")
 
         with mock.patch.object(
-            imp.TestImportProvider,
+            self._harness.imp_provider_class,
             "deploy_replica_target_resources",
             side_effect=injected_error,
         ):

--- a/coriolis/tests/integration/test_smoke.py
+++ b/coriolis/tests/integration/test_smoke.py
@@ -51,7 +51,6 @@ class HarnessSmokeTest(base.CoriolisIntegrationTestBase):
         instances = ["smoke-instance"]
         transfer = self._create_transfer(
             src.id, dst.id, instances=instances,
-            destination_environment={"devices": ["foo"]},
         )
 
         self.assertEqual(src.id, transfer.origin_endpoint_id)

--- a/coriolis/tests/integration/transfers/test_executions.py
+++ b/coriolis/tests/integration/transfers/test_executions.py
@@ -22,8 +22,10 @@ class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
         execution = self._client.transfer_executions.create(
             self._transfer.id, shutdown_instances=False)
         self.addCleanup(
-            self._ignoreExc(self._client.transfer_executions.delete),
-            self._transfer.id, execution.id)
+            self._cleanup_execution,
+            self._transfer.id,
+            execution.id,
+        )
 
         self.assertExecutionCompleted(execution.id)
         executions = self._client.transfer_executions.list(self._transfer.id)
@@ -48,8 +50,10 @@ class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
         execution = self._client.transfer_executions.create(
             self._transfer.id, shutdown_instances=True)
         self.addCleanup(
-            self._client.transfer_executions.delete,
-            self._transfer.id, execution.id)
+            self._cleanup_execution,
+            self._transfer.id,
+            execution.id,
+        )
 
         self.assertExecutionCompleted(execution.id)
 
@@ -60,8 +64,11 @@ class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
             auto_deploy=True,
         )
         self.addCleanup(
-            self._client.transfer_executions.delete,
-            self._transfer.id, execution.id)
+            self._cleanup_execution,
+            self._transfer.id,
+            execution.id,
+        )
+
         self.assertExecutionCompleted(execution.id)
 
         deployments = self._client.deployments.list()
@@ -70,7 +77,7 @@ class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
         ]
         self.assertEqual(1, len(transfer_deployments))
         self.addCleanup(
-            self._client.deployments.delete, transfer_deployments[0].id)
+            self._cleanup_deployment, transfer_deployments[0].id)
 
     def test_cancel_running_execution(self):
         self._test_cancel_running_execution(False)
@@ -93,8 +100,10 @@ class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
         execution = self._client.transfer_executions.create(
             self._transfer.id, shutdown_instances=False)
         self.addCleanup(
-            self._client.transfer_executions.delete,
-            self._transfer.id, execution.id)
+            self._cleanup_execution,
+            self._transfer.id,
+            execution.id,
+        )
 
         # Wait until the execution is RUNNING before issuing the cancel.
         self.wait_for_execution(

--- a/coriolis/tests/integration/transfers/test_executions.py
+++ b/coriolis/tests/integration/transfers/test_executions.py
@@ -7,7 +7,6 @@ Integration tests for the transfer executions.
 
 from coriolis import constants
 from coriolis.tests.integration import base
-from coriolis.tests.integration.test_provider import imp
 
 
 class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
@@ -93,7 +92,7 @@ class TransferExecutionsTests(base.ReplicaIntegrationTestBase):
         """
         # Artificially bump the execution time of a transfer.
         self._patch_add_delay(
-            imp.TestImportProvider,
+            self._harness.imp_provider_class,
             "deploy_replica_target_resources",
         )
 


### PR DESCRIPTION
- Refactor Importer / Exporter class references. They are now referenced through the harness. This will allow them to be swapped in the future.
- Refactor Importer / Exporter connection info.
- Correctly skip Import provider that does not support minion pools. This needs to be done earlier, so the minion pool isn't created on a provider that do not support them.
- raise `AssertionError` instead of using `cls.fail`.
- On transfer execution, we now cancel the execution before deleting it.
- On deployments, we now cancel the deployment before deleting it.
- Updates integration tests' `README.md` file with up-to-date information.