### PR TITLE
Fixes _morph_image calls

### DIFF
--- a/coriolis/osmorphing/manager.py
+++ b/coriolis/osmorphing/manager.py
@@ -173,7 +173,7 @@ def morph_image(origin_provider, destination_provider, connection_info,
     try:
         _morph_image(
             origin_provider, destination_provider, connection_info,
-            osmorphing_info, user_script, event_handler, os_mount_tools,
+            osmorphing_info, user_scripts, event_handler, os_mount_tools,
         )
     finally:
         event_manager.progress_update("Dismounting OS partitions")
@@ -192,7 +192,7 @@ def morph_image(origin_provider, destination_provider, connection_info,
 
 
 def _morph_image(origin_provider, destination_provider, connection_info,
-                 osmorphing_info, user_script, event_handler, os_mount_tools):
+                 osmorphing_info, user_scripts, event_handler, os_mount_tools):
     event_manager = events.EventManager(event_handler)
 
     os_type = osmorphing_info.get('os_type')


### PR DESCRIPTION
A recent change updated `morph_image` to have multiple user scripts. This change was not reflected into `_morph_image`, causing it reference an invalid variable.