### PR TITLE
Fix osmount duplicate boot efi mounts

### DIFF
--- a/coriolis/osmorphing/osmount/base.py
+++ b/coriolis/osmorphing/osmount/base.py
@@ -635,24 +635,8 @@ class BaseLinuxOSMountTools(BaseSSHOSMountTools):
 
     def dismount_os(self, root_dir):
         self._exec_cmd('sudo fuser --kill --mount %s || true' % root_dir)
-        mounted_fs = self._get_mount_destinations()
-        # Sort all mounted filesystems by length. This will ensure that
-        # the first in the list is a subfolder of the next in the list,
-        # and we unmount them in the proper order
-        mounted_fs = list(reversed(sorted(mounted_fs, key=len)))
-        for d in mounted_fs:
-            # umount these two at the very end
-            if d.endswith('/dev') or d.rstrip('/') == root_dir.rstrip('/'):
-                continue
-            if d.startswith(root_dir):
-                # mounted filesystem is a subfolder of our root_dir
-                self._exec_cmd('sudo umount %s' % d)
-
-        dev_fs = "%s/%s" % (root_dir.rstrip('/'), "dev")
-        self._exec_cmd('mountpoint -q %s && sudo umount %s' %
-                       (dev_fs, dev_fs))
         self._exec_cmd(
-            'mountpoint -q %s && sudo umount %s' % (root_dir, root_dir))
+            'mountpoint -q %s && sudo umount -R %s' % (root_dir, root_dir))
 
     def set_proxy(self, proxy_settings):
         url = proxy_settings.get('url')

--- a/coriolis/osmorphing/redhat.py
+++ b/coriolis/osmorphing/redhat.py
@@ -76,8 +76,6 @@ class BaseRedHatMorphingTools(base.BaseLinuxOSMorphingTools):
         refuses to overwrite the wrapper and requires output to
         /boot/grub2/grub.cfg. Prefer the BIOS path when it exists.
         """
-        self._exec_cmd_chroot("mount /boot || true")
-        self._exec_cmd_chroot("mount /boot/efi || true")
         uefi_cfg = os.path.join(self.UEFI_GRUB_LOCATION, "grub.cfg")
         bios_cfg = os.path.join(self.BIOS_GRUB_LOCATION, "grub.cfg")
         # Prefer /boot/grub2/grub.cfg - on RHEL 9.4+ UEFI, the EFI file is a

--- a/coriolis/osmorphing/suse.py
+++ b/coriolis/osmorphing/suse.py
@@ -82,8 +82,6 @@ class BaseSUSEMorphingTools(base.BaseLinuxOSMorphingTools):
         return "grub2-mkconfig -o %s" % location
 
     def _get_grub2_cfg_location(self):
-        self._exec_cmd_chroot("mount /boot || true")
-        self._exec_cmd_chroot("mount /boot/efi || true")
         uefi_cfg = os.path.join(self.UEFI_GRUB_LOCATION, "grub.cfg")
         bios_cfg = os.path.join(self.BIOS_GRUB_LOCATION, "grub.cfg")
         if self._test_path_chroot(uefi_cfg):

--- a/coriolis/tests/osmorphing/osmount/test_base.py
+++ b/coriolis/tests/osmorphing/osmount/test_base.py
@@ -982,26 +982,13 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
     @mock.patch.object(base.BaseSSHOSMountTools, '_exec_cmd')
     def test_dismount_os(self, mock_exec_cmd):
         root_dir = "/mnt/root_dir"
-        mock_exec_cmd.side_effect = [
-            None,
-            ("/dev/sda1 /mnt/root_dir/sub_dir type ext4\n"
-             "/dev/sda2 /mnt/root_dir/dev type ext4\n"
-             "/dev/sda3 /mnt/root_dir type ext4\n"),
-            None,
-            None,
-            None,
-        ]
 
         self.base_os_mount_tools.dismount_os(root_dir)
 
         mock_exec_cmd.assert_has_calls([
             mock.call("sudo fuser --kill --mount /mnt/root_dir || true"),
-            mock.call("cat /proc/mounts"),
-            mock.call("sudo umount /mnt/root_dir/sub_dir"),
-            mock.call("mountpoint -q /mnt/root_dir/dev"
-                      " && sudo umount /mnt/root_dir/dev"),
             mock.call(
-                "mountpoint -q /mnt/root_dir && sudo umount /mnt/root_dir"),
+                "mountpoint -q /mnt/root_dir && sudo umount -R /mnt/root_dir"),
         ])
 
     @mock.patch.object(base.utils, 'get_url_with_credentials')

--- a/coriolis/tests/osmorphing/test_redhat.py
+++ b/coriolis/tests/osmorphing/test_redhat.py
@@ -68,44 +68,30 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             'grub2-mkconfig -o %s' % mock_get_grub2_cfg_location.return_value
         )
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
-    def test__get_grub2_cfg_location_bios(self, mock_test_path_chroot,
-                                          mock_exec_cmd_chroot):
+    def test__get_grub2_cfg_location_bios(self, mock_test_path_chroot):
         mock_test_path_chroot.return_value = True
 
         result = self.morphing_tools._get_grub2_cfg_location()
 
         self.assertEqual(result, '/boot/grub2/grub.cfg')
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call("mount /boot || true"),
-            mock.call("mount /boot/efi || true")
-        ])
         mock_test_path_chroot.assert_called_once_with(
             '/boot/grub2/grub.cfg')
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
-    def test__get_grub2_cfg_location_uefi(self, mock_test_path_chroot,
-                                          mock_exec_cmd_chroot):
+    def test__get_grub2_cfg_location_uefi(self, mock_test_path_chroot):
         mock_test_path_chroot.side_effect = [False, True]
 
         result = self.morphing_tools._get_grub2_cfg_location()
 
         self.assertEqual(result, '/boot/efi/EFI/redhat/grub.cfg')
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call("mount /boot || true"),
-            mock.call("mount /boot/efi || true")
-        ])
         mock_test_path_chroot.assert_has_calls([
             mock.call('/boot/grub2/grub.cfg'),
             mock.call('/boot/efi/EFI/redhat/grub.cfg')
         ])
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
-    def test__get_grub2_cfg_location_unknown(self, mock_test_path_chroot,
-                                             mock_exec_cmd_chroot):
+    def test__get_grub2_cfg_location_unknown(self, mock_test_path_chroot):
         mock_test_path_chroot.return_value = False
 
         self.assertRaisesRegex(
@@ -114,10 +100,6 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             self.morphing_tools._get_grub2_cfg_location
         )
 
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call("mount /boot || true"),
-            mock.call("mount /boot/efi || true")
-        ])
         mock_test_path_chroot.assert_has_calls([
             mock.call('/boot/grub2/grub.cfg'),
             mock.call('/boot/efi/EFI/redhat/grub.cfg')

--- a/coriolis/tests/osmorphing/test_suse.py
+++ b/coriolis/tests/osmorphing/test_suse.py
@@ -117,43 +117,27 @@ class BaseSUSEMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             "grub2-mkconfig -o %s" % mock_get_grub2_cfg_location.return_value
         )
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
-    def test__get_grub2_cfg_location_uefi(self, mock_test_path_chroot,
-                                          mock_exec_cmd_chroot):
+    def test__get_grub2_cfg_location_uefi(self, mock_test_path_chroot):
         mock_test_path_chroot.return_value = True
 
         result = self.morphing_tools._get_grub2_cfg_location()
 
         self.assertEqual(result, '/boot/efi/EFI/suse/grub.cfg')
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call("mount /boot || true"),
-            mock.call("mount /boot/efi || true")
-        ])
         mock_test_path_chroot.assert_called_once_with(
             '/boot/efi/EFI/suse/grub.cfg')
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
-    def test__get_grub2_cfg_location_bios(self, mock_test_path_chroot,
-                                          mock_exec_cmd_chroot):
+    def test__get_grub2_cfg_location_bios(self, mock_test_path_chroot):
         mock_test_path_chroot.side_effect = [False, True]
 
         result = self.morphing_tools._get_grub2_cfg_location()
 
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call("mount /boot || true"),
-            mock.call("mount /boot/efi || true")
-        ])
-        mock_test_path_chroot.assert_called_with(
-            '/boot/grub2/grub.cfg')
-
+        mock_test_path_chroot.assert_called_with('/boot/grub2/grub.cfg')
         self.assertEqual(result, '/boot/grub2/grub.cfg')
 
-    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path_chroot')
-    def test__get_grub2_cfg_location_not_found(self, mock_test_path_chroot,
-                                               mock_exec_cmd_chroot):
+    def test__get_grub2_cfg_location_not_found(self, mock_test_path_chroot):
         mock_test_path_chroot.return_value = False
 
         self.assertRaisesRegex(
@@ -161,10 +145,6 @@ class BaseSUSEMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             "could not determine grub location. boot partition not mounted?",
             self.morphing_tools._get_grub2_cfg_location
         )
-        mock_exec_cmd_chroot.assert_has_calls([
-            mock.call("mount /boot || true"),
-            mock.call("mount /boot/efi || true")
-        ])
         mock_test_path_chroot.assert_has_calls([
             mock.call('/boot/efi/EFI/suse/grub.cfg'),
             mock.call('/boot/grub2/grub.cfg')


### PR DESCRIPTION
This PR implements the following changes:

- Replaces the `dismount_os` sorting logic with `umount -R`;
- Removes redundant boot partition mounts from `_get_grub2_cfg_location`.