### PR TITLE
Reject empty user scripts

### DIFF
--- a/coriolis/api/v1/utils.py
+++ b/coriolis/api/v1/utils.py
@@ -104,6 +104,10 @@ def _process_user_scripts(
         payload = user_scripts
         if sanitize_newlines:
             payload = _sanitize_newlines(payload)
+        if not payload.strip("\r\n "):
+            raise exception.InvalidInput(
+                "Empty script received. "
+                "Use 'None' if the script should be removed.")
         return [
             {
                 "phase": constants.PHASE_OSMORPHING_POST_OS_MOUNT,
@@ -141,6 +145,10 @@ def _process_user_scripts(
             if sanitize_newlines:
                 script_item["payload"] = _sanitize_newlines(
                     script_item["payload"])
+            if not script_item["payload"].strip("\r\n "):
+                raise exception.InvalidInput(
+                    "Empty script received. "
+                    "Use 'None' if the script should be removed.")
 
         return user_scripts
     else:

--- a/coriolis/tests/api/v1/data/utils_validate_user_scripts_raises.yml
+++ b/coriolis/tests/api/v1/data/utils_validate_user_scripts_raises.yml
@@ -14,3 +14,30 @@
       linux: 'mock_scripts_linux'
       windows: 'mock_scripts_windows'
     instances: "invalid"
+
+- user_scripts:
+    global:
+      linux: ''
+
+- user_scripts:
+    global:
+      instances:
+        some_instance: ''
+
+- user_scripts:
+    global:
+      linux:
+      - phase: osmorphing_post_os_mount
+        payload: ''
+
+- user_scripts:
+    global:
+      instances:
+        some_instance: ''
+
+- user_scripts:
+    global:
+      instances:
+        some_instance:
+        - phase: osmorphing_post_os_mount
+          payload: ''


### PR DESCRIPTION
Coriolis allows removing user scripts by specifying "None" instead of a user script.

As mentioned here [1], an empty string is most likely an user error though and we should reject the request.

[1] https://github.com/cloudbase/coriolis/pull/448#discussion_r3350559746