### PR TITLE
Fix issue of trying to decode a str

### DIFF
--- a/coriolis/osmorphing/netpreserver/interfaces.py
+++ b/coriolis/osmorphing/netpreserver/interfaces.py
@@ -31,7 +31,7 @@ class InterfacesNetPreserver(base.BaseNetPreserver):
             curr_ip_address = None
             curr_iface = None
             interfaces_contents = self.osmorphing_tool._read_file_sudo(
-                interface_file).decode()
+                interface_file)
             LOG.debug(
                 "Fetched %s contents: %s", interface_file, interfaces_contents)
             for line in interfaces_contents.splitlines():

--- a/coriolis/tests/osmorphing/netpreserver/test_interfaces.py
+++ b/coriolis/tests/osmorphing/netpreserver/test_interfaces.py
@@ -69,7 +69,7 @@ class InterfacesNetPreserverTestCase(test_base.CoriolisBaseTestCase):
             "iface eth1 inet dhcp\n"
             "address 192.168.1.20/24\n"
         )
-        mock_read_file_sudo.return_value = interfaces_content.encode()
+        mock_read_file_sudo.return_value = interfaces_content
         mock_test_path.return_value = True
         mock_exec_cmd_chroot.return_value = ""
 
@@ -109,7 +109,7 @@ class InterfacesNetPreserverTestCase(test_base.CoriolisBaseTestCase):
         mock_test_path.return_value = True
         mock_exec_cmd_chroot.return_value = extra_file
         mock_read_file_sudo.side_effect = (
-            main_content.encode(), extra_content.encode()
+            main_content, extra_content
         )
 
         self.netpreserver.parse_network()
@@ -136,7 +136,7 @@ class InterfacesNetPreserverTestCase(test_base.CoriolisBaseTestCase):
         interfaces_content = (
             "hwaddress ether 00:11:22:33:44:55\n"
         )
-        mock_read_file_sudo.return_value = interfaces_content.encode()
+        mock_read_file_sudo.return_value = interfaces_content
         mock_test_path.return_value = True
         mock_exec_cmd_chroot.return_value = ""
 


### PR DESCRIPTION
This fixes an error where _parse_iface_file tries to decode a str. The output of the command getting executed is already getting decoded in coriolis/utils.py exec_cmd_ssh introduced in commit 539fabb9d302b3915cda19357ba0d0ea6d33d25f