### PR TITLE
Add support for detecting rocky and centos 10

### DIFF
--- a/coriolis/osmorphing/osdetect/centos.py
+++ b/coriolis/osmorphing/osdetect/centos.py
@@ -23,7 +23,7 @@ class CentOSOSDetectTools(base.BaseLinuxOSDetectTools):
             release_info = self._read_file(
                 redhat_release_path).decode().splitlines()
             if release_info:
-                m = re.match(r"^(.*) release ([0-9](\.[0-9])*)( \(.*\))?.*$",
+                m = re.match(r"^(.*) release ([0-9]+(\.[0-9]+)*)( \(.*\))?.*$",
                              release_info[0].strip())
                 if m:
                     distro, version, _, _ = m.groups()

--- a/coriolis/osmorphing/osdetect/rocky.py
+++ b/coriolis/osmorphing/osdetect/rocky.py
@@ -21,7 +21,7 @@ class RockyLinuxOSDetectTools(base.BaseLinuxOSDetectTools):
             release_info = self._read_file(
                 redhat_release_path).decode().splitlines()
             if release_info:
-                m = re.match(r"^(.*) release ([0-9](\.[0-9])*)( \(.*\))?.*$",
+                m = re.match(r"^(.*) release ([0-9]+(\.[0-9]+)*)( \(.*\))?.*$",
                              release_info[0].strip())
                 if m:
                     distro, version, _, _ = m.groups()

--- a/coriolis/tests/osmorphing/osdetect/test_centos.py
+++ b/coriolis/tests/osmorphing/osdetect/test_centos.py
@@ -62,6 +62,24 @@ class CentOSOSDetectToolsTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(base.BaseLinuxOSDetectTools, '_test_path')
     @mock.patch.object(base.BaseLinuxOSDetectTools, '_read_file')
+    def test_detect_os_centos_stream_10(self, mock_read_file, mock_test_path):
+        mock_test_path.return_value = True
+        mock_read_file.return_value = b"CentOS Stream release 10"
+
+        expected_info = {
+            "os_type": centos.constants.OS_TYPE_LINUX,
+            "distribution_name": centos.CENTOS_STREAM_DISTRO_IDENTIFIER,
+            "release_version": '10',
+            "friendly_release_name": "%s Version %s" % (
+                centos.CENTOS_STREAM_DISTRO_IDENTIFIER, '10')
+        }
+
+        result = self.centos_os_detect_tools.detect_os()
+
+        self.assertEqual(result, expected_info)
+
+    @mock.patch.object(base.BaseLinuxOSDetectTools, '_test_path')
+    @mock.patch.object(base.BaseLinuxOSDetectTools, '_read_file')
     def test_detect_os_not_centos(self, mock_read_file, mock_test_path):
         mock_test_path.return_value = True
         mock_read_file.return_value = b"dummy release 8.3"

--- a/coriolis/tests/osmorphing/osdetect/test_rocky.py
+++ b/coriolis/tests/osmorphing/osdetect/test_rocky.py
@@ -36,6 +36,28 @@ class RockyLinuxOSDetectToolsTestCase(test_base.CoriolisBaseTestCase):
 
     @mock.patch.object(base.BaseLinuxOSDetectTools, '_test_path')
     @mock.patch.object(base.BaseLinuxOSDetectTools, '_read_file')
+    def test_detect_os_rocky_10(self, mock_read_file, mock_test_path):
+        mock_test_path.return_value = True
+        mock_read_file.return_value = (
+            b"Rocky Linux release 10.1 (Red Quartz)")
+
+        expected_info = {
+            "os_type": rocky.constants.OS_TYPE_LINUX,
+            "distribution_name": rocky.ROCKY_LINUX_DISTRO_IDENTIFIER,
+            "release_version": '10.1',
+            "friendly_release_name": "Rocky Linux Version 10.1"
+        }
+
+        rocky_os_detect_tools = rocky.RockyLinuxOSDetectTools(
+            mock.sentinel.conn, mock.sentinel.os_root_dir,
+            mock.sentinel.operation_timeout)
+
+        result = rocky_os_detect_tools.detect_os()
+
+        self.assertEqual(result, expected_info)
+
+    @mock.patch.object(base.BaseLinuxOSDetectTools, '_test_path')
+    @mock.patch.object(base.BaseLinuxOSDetectTools, '_read_file')
     def test_detect_os_no_rocky(self, mock_read_file, mock_test_path):
         mock_test_path.return_value = True
         mock_read_file.return_value = b"CentOS Linux release 8.4"


### PR DESCRIPTION
With the current implementation, Rocky10 and CentOS10 are selected as Rocky1 and CentOS1, rather than their proper version.
This PR updates the regex to properly pick those.