### PR TITLE
tests: Minor adjustments for external providers

### DIFF
--- a/coriolis/tests/integration/base.py
+++ b/coriolis/tests/integration/base.py
@@ -72,6 +72,7 @@ class CoriolisIntegrationTestBase(test_base.CoriolisBaseTestCase):
         cls._imp_conn_info = cls._harness.imp_conn_info
         cls._imp_env_options = cls._harness.imp_env_options
         cls._storage_mappings = cls._harness.imp_storage_mappings
+        cls._pool_env = cls._harness.imp_minion_pool_environment
 
         cls._client = cls.get_client()
 
@@ -167,7 +168,7 @@ class CoriolisIntegrationTestBase(test_base.CoriolisBaseTestCase):
             endpoint=endpoint_id,
             platform=constants.PROVIDER_PLATFORM_DESTINATION,
             os_type=constants.OS_TYPE_LINUX,
-            environment_options={},
+            environment_options=cls._pool_env,
             minimum_minions=1,
             maximum_minions=1,
             minion_max_idle_time=3600,

--- a/coriolis/tests/integration/harness.py
+++ b/coriolis/tests/integration/harness.py
@@ -116,6 +116,8 @@ def _load_providers_config():
             "connection_info": dest_config.get("connection_info"),
             "environment": dest_config.get("environment") or {},
             "storage_mappings": dest_config.get("storage_mappings") or {},
+            "minion_pool_environment": (
+                dest_config.get("minion_pool_environment") or {}),
         },
     }
 
@@ -379,6 +381,9 @@ class _IntegrationHarness:
         self.imp_env_options = providers_config["destination"]["environment"]
         self.imp_storage_mappings = (
             providers_config["destination"]["storage_mappings"]
+        )
+        self.imp_minion_pool_environment = (
+            providers_config["destination"]["minion_pool_environment"]
         )
 
         self._wsgi_server = None

--- a/coriolis/tests/integration/providers.yaml.sample
+++ b/coriolis/tests/integration/providers.yaml.sample
@@ -26,3 +26,6 @@ destination:
 
   # Storage backend mapping (source identifier -> destination pool / datastore).
   storage_mappings: {}
+
+  # environment options forwarded to destination minion pools.
+  minion_pool_environment: {}

--- a/coriolis/tests/integration/test_provider/exp.py
+++ b/coriolis/tests/integration/test_provider/exp.py
@@ -28,6 +28,15 @@ from coriolis.tests.integration import utils as test_utils
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
+# Real VMs always have at least one NIC; destination providers may reject an
+# instance with no NIC. "network_map" in the destination's environment options
+# must map "test-network" to an existing network on the destination.
+_TEST_NIC = {
+    "id": "fa:16:3e:12:34:56",
+    "network_name": "test-network",
+    "mac_address": "fa:16:3e:12:34:56",
+}
+
 
 class TestExportProvider(
         BaseEndpointInstancesProvider,
@@ -125,7 +134,7 @@ class TestExportProvider(
             "nested_virtualization": False,
             "devices": {
                 "disks": [],
-                "nics": [],
+                "nics": [_TEST_NIC],
                 "cdroms": [],
                 "serial_ports": [],
                 "floppies": [],
@@ -180,7 +189,7 @@ class TestExportProvider(
                         "size_bytes": size_bytes,
                     }
                 ],
-                "nics": [],
+                "nics": [_TEST_NIC],
                 "cdroms": [],
                 "serial_ports": [],
                 "floppies": [],


### PR DESCRIPTION
Wire in `providers.yaml` minion pool environment.

The `TestExportProvider` now reports one NIC; some providers error out if no NIC is reported.