### PR TITLE
tests: Update tests to use autospecs instead of specs

### DIFF
--- a/coriolis/tests/minion_manager/rpc/test_tasks.py
+++ b/coriolis/tests/minion_manager/rpc/test_tasks.py
@@ -28,7 +28,7 @@ class MinionManagerTaskEventMixinTestCase(test_base.CoriolisBaseTestCase):
     def test__conductor_client(self):
         with mock.patch(
             'coriolis.conductor.rpc.client.ConductorClient',
-                return_value=mock.MagicMock(spec=ConductorClient)) as \
+                return_value=mock.MagicMock(autospec=ConductorClient)) as \
                 mock_Conductor_client:
             result = self.task._conductor_client
 
@@ -42,7 +42,7 @@ class MinionManagerTaskEventMixinTestCase(test_base.CoriolisBaseTestCase):
             'coriolis.conductor.rpc.client.ConductorClient') as \
                 mock_Conductor_client:
             self.task._conductor_client_instance = mock.MagicMock(
-                spec=ConductorClient)
+                autospec=ConductorClient)
 
             result = self.task._conductor_client
 
@@ -54,7 +54,7 @@ class MinionManagerTaskEventMixinTestCase(test_base.CoriolisBaseTestCase):
     def test__minion_manager_client(self):
         with mock.patch(
             'coriolis.minion_manager.rpc.client.MinionManagerClient',
-                return_value=mock.MagicMock(spec=MinionManagerClient)) as \
+                return_value=mock.MagicMock(autospec=MinionManagerClient)) as \
                 mock_Minion_Manager_Client:
             result = self.task._minion_manager_client
 
@@ -68,7 +68,7 @@ class MinionManagerTaskEventMixinTestCase(test_base.CoriolisBaseTestCase):
             'coriolis.minion_manager.rpc.client.MinionManagerClient') as \
                 mock_Minion_Manager_Client:
             self.task._minion_manager_client_instance = mock.MagicMock(
-                spec=MinionManagerClient)
+                autospec=MinionManagerClient)
 
             result = self.task._minion_manager_client
 
@@ -991,7 +991,7 @@ class AllocateMinionMachineTaskTestCase(test_base.CoriolisBaseTestCase):
             'pool_identifier': 'test_identifier',
             'pool_os_type': 'linux',
         }
-        self.mock_failure = mock.MagicMock(spec=failure.Failure)
+        self.mock_failure = mock.MagicMock(autospec=failure.Failure)
 
         self.task = tasks.AllocateMinionMachineTask(
             self.minion_pool_id, self.minion_machine_id,
@@ -1316,7 +1316,7 @@ class DeallocateMinionMachineTaskTestCase(test_base.CoriolisBaseTestCase):
         self.task_info = {
             'minion_provider_properties': None,
         }
-        self.mock_failure = mock.MagicMock(spec=failure.Failure)
+        self.mock_failure = mock.MagicMock(autospec=failure.Failure)
 
         self.task = tasks.DeallocateMinionMachineTask(
             self.minion_pool_id, self.minion_machine_id,

--- a/coriolis/tests/osmorphing/osdetect/test_manager.py
+++ b/coriolis/tests/osmorphing/osdetect/test_manager.py
@@ -62,7 +62,8 @@ class ManagerTestCase(test_base.CoriolisBaseTestCase):
 
     def test__check_custom_os_detect_tools(self):
         # Create a mock object that is an instance of BaseOSDetectTools
-        mock_os_detect_tool = mock.MagicMock(spec=base.BaseOSDetectTools)
+        mock_os_detect_tool = mock.create_autospec(
+            base.BaseOSDetectTools, instance=True)
 
         result = manager._check_custom_os_detect_tools([mock_os_detect_tool])
 

--- a/coriolis/tests/providers/test_backup_writers.py
+++ b/coriolis/tests/providers/test_backup_writers.py
@@ -70,7 +70,8 @@ class BackupWritersTestCase(test_base.CoriolisBaseTestCase):
         mock_exec_ssh_cmd.assert_has_calls(expected_calls)
 
     def test__check_deserialize_key(self):
-        mock_rsa_key = mock.MagicMock(spec=backup_writers.paramiko.RSAKey)
+        mock_rsa_key = mock.create_autospec(
+            backup_writers.paramiko.RSAKey, instance=True)
 
         result = backup_writers._check_deserialize_key(mock_rsa_key)
 

--- a/coriolis/tests/providers/test_replicator.py
+++ b/coriolis/tests/providers/test_replicator.py
@@ -8,6 +8,7 @@ from unittest import mock
 from oslo_utils import units
 
 from coriolis import exception
+from coriolis.providers import backup_writers
 from coriolis.providers import provider_utils
 from coriolis.providers import replicator as replicator_module
 from coriolis.tests import test_base
@@ -1179,7 +1180,8 @@ class ReplicatorTestCase(test_base.CoriolisBaseTestCase):
         source_volumes_info = [
             {"disk_id": "test_disk", "disk_path": "/dev/sdb"}]
         self.replicator._repl_state = ['non-empty']
-        mock_destination = mock.MagicMock(spec=['seek', 'write'])
+        mock_destination = mock.MagicMock(
+            autospec=backup_writers.BaseBackupWriterImpl)
         self.backup_writer.open.return_value.__enter__.return_value = (
             mock_destination)
 

--- a/coriolis/tests/taskflow/test_base.py
+++ b/coriolis/tests/taskflow/test_base.py
@@ -74,7 +74,7 @@ class BaseCoriolisTaskflowTaskTestCase(test_base.CoriolisBaseTestCase):
             self.task.revert(self.mock_instance, mock.ANY)
 
     def test_revert_with_error(self):
-        mock_failure = mock.Mock(spec=failure.Failure)
+        mock_failure = mock.Mock(autospec=failure.Failure)
         mock_failure.traceback_str = "Mock traceback"
         with self.assertLogs('coriolis.taskflow.base', level=logging.ERROR):
             self.task.revert(result=mock_failure)
@@ -95,7 +95,7 @@ class BaseRunWorkerTaskTestCase(test_base.CoriolisBaseTestCase):
         self.mock_cleanup_task_runner = mock.Mock()
 
     def test_scheduler_client_property(self):
-        mock_scheduler_client = mock.Mock(spec=SchedulerClient)
+        mock_scheduler_client = mock.Mock(autospec=SchedulerClient)
 
         with mock.patch('coriolis.scheduler.rpc.client.SchedulerClient',
                         return_value=mock_scheduler_client):
@@ -104,7 +104,7 @@ class BaseRunWorkerTaskTestCase(test_base.CoriolisBaseTestCase):
                              mock_scheduler_client)
 
     def test_scheduler_client_already_set(self):
-        mock_scheduler_client = mock.Mock(spec=SchedulerClient)
+        mock_scheduler_client = mock.Mock(autospec=SchedulerClient)
         self.task._scheduler_client_instance = mock_scheduler_client
 
         with mock.patch('coriolis.scheduler.rpc.client.SchedulerClient') as \

--- a/coriolis/tests/tasks/test_minion_pool_tasks.py
+++ b/coriolis/tests/tasks/test_minion_pool_tasks.py
@@ -555,15 +555,14 @@ class _BaseValidateMinionCompatibilityTaskTestCase(
         ("invalid", None),
     )
     def test__get_transfer_properties_task_info_field(self, data):
-        test_fun = mp_tasks._BaseValidateMinionCompatibilityTask\
-            ._get_transfer_properties_task_info_field
-        with mock.patch.object(mp_tasks._BaseValidateMinionCompatibilityTask,
-                               'get_required_platform', return_value=data[0]):
-            if not data[1]:
-                self.assertRaises(exception.CoriolisException, test_fun)
-                return
+        base_class = mp_tasks._BaseValidateMinionCompatibilityTask
+        test_fun = base_class._get_transfer_properties_task_info_field
+        base_class.get_required_platform.return_value = data[0]
+        if not data[1]:
+            self.assertRaises(exception.CoriolisException, test_fun)
+            return
 
-            self.assertEqual(test_fun(), data[1])
+        self.assertEqual(test_fun(), data[1])
 
     @mock.patch.object(mp_tasks._BaseValidateMinionCompatibilityTask,
                        '_get_transfer_properties_task_info_field',

--- a/coriolis/tests/test_base.py
+++ b/coriolis/tests/test_base.py
@@ -6,6 +6,7 @@
 from unittest import mock
 
 from oslotest import base
+from oslotest import mock_fixture
 
 from coriolis.api.v1.views import utils as views_utils
 
@@ -14,6 +15,7 @@ class CoriolisBaseTestCase(base.BaseTestCase):
 
     def setUp(self):
         super(CoriolisBaseTestCase, self).setUp()
+        self.useFixture(mock_fixture.MockAutospecFixture())
 
 
 class CoriolisApiViewsTestCase(CoriolisBaseTestCase):


### PR DESCRIPTION
Autospecs are stricter than regular specs, enforcing mocked function calls to respect the original function's signature.

`autospec` is not a standard argument in the mock library, which is why `mock_fixture.MockAutospecFixture()` is needed.