### PR TITLE
Add real_time_clock_utc option to cloudbase_init_conf (default=False)

### DIFF
--- a/coriolis/osmorphing/windows.py
+++ b/coriolis/osmorphing/windows.py
@@ -498,7 +498,8 @@ class BaseWindowsMorphingTools(base.BaseOSMorphingTools):
 
     def _write_cloudbase_init_conf(self, cloudbaseinit_base_dir,
                                    local_base_dir, com_port="COM1",
-                                   metadata_services=None, plugins=None):
+                                   metadata_services=None, plugins=None,
+                                   real_time_clock_utc: bool = False):
         if metadata_services is None:
             metadata_services = CLOUDBASE_INIT_DEFAULT_METADATA_SVCS
 
@@ -537,13 +538,15 @@ class BaseWindowsMorphingTools(base.BaseOSMorphingTools):
             "debug = true\r\n"
             "san_policy = OnlineAll\r\n"
             "metadata_services = %(metadata_services)s\r\n"
-            "logging_serial_port_settings = %(com_port)s,9600,N,8\r\n" %
+            "logging_serial_port_settings = %(com_port)s,9600,N,8\r\n"
+            "real_time_clock_utc = %(real_time_clock_utc)s\r\n" %
             {"bin_path": "%s\\Bin" % local_base_dir,
              "log_path": "%s\\Log" % local_base_dir,
              "scripts_path": "%s\\LocalScripts" % local_base_dir,
              "com_port": com_port,
              "metadata_services": ",".join(metadata_services),
-             "plugins": ",".join(plugins)})
+             "plugins": ",".join(plugins),
+             "real_time_clock_utc": real_time_clock_utc})
 
         utils.write_winrm_file(
             self._conn,
@@ -560,7 +563,8 @@ class BaseWindowsMorphingTools(base.BaseOSMorphingTools):
 
     def _install_cloudbase_init(self, download_url,
                                 metadata_services=None, enabled_plugins=None,
-                                com_port="COM1"):
+                                com_port="COM1",
+                                real_time_clock_utc: bool = False):
         self._event_manager.progress_update("Adding cloudbase-init")
         cloudbaseinit_base_dir = self._get_cbslinit_base_dir()
 
@@ -589,7 +593,8 @@ class BaseWindowsMorphingTools(base.BaseOSMorphingTools):
             self._write_cloudbase_init_conf(
                 cloudbaseinit_base_dir, local_base_dir,
                 metadata_services=metadata_services,
-                plugins=enabled_plugins, com_port=com_port)
+                plugins=enabled_plugins, com_port=com_port,
+                real_time_clock_utc=real_time_clock_utc)
 
             image_path = (
                 '"%(path)s\\Bin\\OpenStackService.exe" cloudbase-init '

--- a/coriolis/tests/osmorphing/test_windows.py
+++ b/coriolis/tests/osmorphing/test_windows.py
@@ -527,14 +527,16 @@ class BaseWindowsMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
             "debug = true\r\n"
             "san_policy = OnlineAll\r\n"
             "metadata_services = %(metadata_services)s\r\n"
-            "logging_serial_port_settings = %(com_port)s,9600,N,8\r\n" %
+            "logging_serial_port_settings = %(com_port)s,9600,N,8\r\n"
+            "real_time_clock_utc = %(real_time_clock_utc)s\r\n" %
             {"bin_path": "%s\\Bin" % local_base_dir,
              "log_path": "%s\\Log" % local_base_dir,
              "scripts_path": "%s\\LocalScripts" % local_base_dir,
              "com_port": 'COM1',
              "metadata_services": ",".join(
                  windows.CLOUDBASE_INIT_DEFAULT_METADATA_SVCS),
-             "plugins": ",".join(windows.CLOUDBASE_INIT_DEFAULT_PLUGINS)})
+             "plugins": ",".join(windows.CLOUDBASE_INIT_DEFAULT_PLUGINS),
+             "real_time_clock_utc": False})
 
         mock_write_winrm_file.assert_called_once_with(
             self.conn, conf_file_path, conf_content)
@@ -604,7 +606,8 @@ class BaseWindowsMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
 
         mock_write_cloudbase_init_conf.assert_called_once_with(
             cloudbaseinit_base_dir, local_base_dir,
-            metadata_services=None, plugins=None, com_port='COM1')
+            metadata_services=None, plugins=None, com_port='COM1',
+            real_time_clock_utc=False)
         mock_check_cloudbase_init_exists.assert_called_once_with(
             str(mock_uuid4.return_value))
 
@@ -678,7 +681,8 @@ class BaseWindowsMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
 
         mock_write_cloudbase_init_conf.assert_called_once_with(
             cloudbaseinit_base_dir, local_base_dir,
-            metadata_services=None, plugins=None, com_port='COM1')
+            metadata_services=None, plugins=None, com_port='COM1',
+            real_time_clock_utc=False)
         mock_setup_existing_cbslinit_service.assert_called_once_with(
             str(mock_uuid4.return_value), expected_image_path)
         mock_create_service.assert_not_called()


### PR DESCRIPTION
This PR adds the option to configure `real_time_clock_utc` in the cloudbase-init config (default value is `False`, as per cloudbase-init docs) to fix issues when Windows VMs are migrated and the time is changes to UTC for a few moments. 

The issues were seen when migrating Windows VMs to LXD, and the VM was firstly setting time to UTC and just after a few moments, it got changed back to what was on the source.