### PR TITLE
Move `SELinux autorelabeling` to base classes

### DIFF
--- a/coriolis/osmorphing/redhat.py
+++ b/coriolis/osmorphing/redhat.py
@@ -235,6 +235,7 @@ class BaseRedHatMorphingTools(base.BaseLinuxOSMorphingTools):
     def post_packages_install(self, package_names):
         self._configure_cloud_init()
         self._run_dracut()
+        self._set_selinux_autorelabel()
         super(BaseRedHatMorphingTools, self).post_packages_install(
             package_names)
 

--- a/coriolis/osmorphing/suse.py
+++ b/coriolis/osmorphing/suse.py
@@ -189,6 +189,7 @@ class BaseSUSEMorphingTools(base.BaseLinuxOSMorphingTools):
     def post_packages_install(self, package_names):
         self._configure_cloud_init()
         self._run_dracut()
+        self._set_selinux_autorelabel()
         super(BaseSUSEMorphingTools, self).post_packages_install(package_names)
 
     def _enable_sles_module(self, module):

--- a/coriolis/tests/osmorphing/test_redhat.py
+++ b/coriolis/tests/osmorphing/test_redhat.py
@@ -687,17 +687,20 @@ class BaseRedHatMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
         mock_yum_clean_all.assert_called_once()
         mock_yum_install.assert_not_called()
 
+    @mock.patch.object(
+        redhat.BaseRedHatMorphingTools, '_set_selinux_autorelabel')
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_configure_cloud_init')
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_run_dracut')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, 'post_packages_install')
     def test_post_packages_install(
             self, mock_post_packages_install, mock__run_dracut,
-            mock__configure_cloud_init):
+            mock__configure_cloud_init, mock__set_selinux_autorelabel):
 
         self.morphing_tools.post_packages_install(self.package_names)
 
         mock__configure_cloud_init.assert_called_once()
         mock__run_dracut.assert_called_once()
+        mock__set_selinux_autorelabel.assert_called_once()
         mock_post_packages_install.assert_called_once_with(self.package_names)
 
     @mock.patch.object(redhat.BaseRedHatMorphingTools, '_yum_install')

--- a/coriolis/tests/osmorphing/test_suse.py
+++ b/coriolis/tests/osmorphing/test_suse.py
@@ -205,17 +205,19 @@ class BaseSUSEMorphingToolsTestCase(test_base.CoriolisBaseTestCase):
 
         self.assertFalse(result)
 
+    @mock.patch.object(suse.BaseSUSEMorphingTools, '_set_selinux_autorelabel')
     @mock.patch.object(suse.BaseSUSEMorphingTools, '_configure_cloud_init')
     @mock.patch.object(suse.BaseSUSEMorphingTools, '_run_dracut')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, 'post_packages_install')
     def test_post_packages_install(
             self, mock_post_packages_install, mock__run_dracut,
-            mock__configure_cloud_init):
+            mock__configure_cloud_init, mock__set_selinux_autorelabel):
 
         self.morphing_tools.post_packages_install(self.package_names)
 
         mock__configure_cloud_init.assert_called_once()
         mock__run_dracut.assert_called_once()
+        mock__set_selinux_autorelabel.assert_called_once()
         mock_post_packages_install.assert_called_once_with(self.package_names)
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')


### PR DESCRIPTION
This ensures all `Red Hat` and `SUSE` distribution variants execute `SELinux autorelabeling` consistently at the same point in the post-install lifecycle.