### PR TITLE
Extends integration tests code coverage and fixes related issues

### DIFF
--- a/coriolis/api/wsgi.py
+++ b/coriolis/api/wsgi.py
@@ -1241,10 +1241,10 @@ class Fault(webob.exc.HTTPException):
             if retry:
                 fault_data[fault_name]['retryAfter'] = retry
 
-        content_type = req.best_match_content_type()
-        serializer = {
-            'application/json': JSONDictSerializer(),
-        }[content_type]
+        # Error responses are always JSON, regardless of what content type the
+        # client requested (e.g.: 'text/csv' for CSV-producing endpoints).
+        content_type = 'application/json'
+        serializer = JSONDictSerializer()
 
         body = serializer.serialize(fault_data)
         if isinstance(body, six.text_type):
@@ -1313,7 +1313,6 @@ class OverLimitFault(webob.exc.HTTPException):
     @webob.dec.wsgify(RequestClass=Request)
     def __call__(self, request):
         """Serializes the wrapped exception conforming to our error format."""
-        content_type = request.best_match_content_type()
 
         def translate(msg):
             locale = request.best_match_language()
@@ -1324,9 +1323,9 @@ class OverLimitFault(webob.exc.HTTPException):
         self.content['overLimitFault']['details'] = \
             translate(self.content['overLimitFault']['details'])
 
-        serializer = {
-            'application/json': JSONDictSerializer(),
-        }[content_type]
+        # Error responses are always JSON, regardless of what content
+        # type the client requested.
+        serializer = JSONDictSerializer()
 
         content = serializer.serialize(self.content)
         self.wrapped_exc.body = content

--- a/coriolis/tasks/minion_pool_tasks.py
+++ b/coriolis/tasks/minion_pool_tasks.py
@@ -565,14 +565,15 @@ class AttachVolumesToOSMorphingMinionTask(
 
     @classmethod
     def _get_volumes_info_from_task_info(cls, task_info):
-        return task_info[
-            "instance_deployment_info"]["volumes_info"]
+        # Similar to _BaseAttachVolumesToTransferMinionTask.
+        return task_info["volumes_info"]
 
     @classmethod
     def get_required_task_info_properties(cls):
         fields = super(
             AttachVolumesToOSMorphingMinionTask,
             cls).get_required_task_info_properties()
+        fields.append("volumes_info")
         fields.append("instance_deployment_info")
         return fields
 

--- a/coriolis/tests/integration/deployments/test_osmorphing.py
+++ b/coriolis/tests/integration/deployments/test_osmorphing.py
@@ -12,12 +12,14 @@ import re
 import unittest
 import uuid
 
+from coriolis.db import api as db_api
 from coriolis.tests.integration import base as integration_base
 from coriolis.tests.integration import harness as integration_harness
 from coriolis.tests.integration import osmorphing_utils
 
 
-class OsMorphingDeploymentTest(integration_base.ReplicaIntegrationTestBase):
+class OsMorphingDeploymentTestBase(
+        integration_base.ReplicaIntegrationTestBase):
 
     # NOTE(claudiub): Size must be high enough to contain the tested OS and
     # any new packages to be added during OS morphing.
@@ -36,6 +38,8 @@ class OsMorphingDeploymentTest(integration_base.ReplicaIntegrationTestBase):
         osmorphing_utils.write_os_image_to_disk(
             self._src_device, "ubuntu:24.04")
 
+
+class OsMorphingDeploymentTest(OsMorphingDeploymentTestBase):
     def test_deployment_with_os_morphing(self):
         self.assertFalse(
             osmorphing_utils.path_exists_on_device(
@@ -192,3 +196,43 @@ class OsMorphingDeploymentTest(integration_base.ReplicaIntegrationTestBase):
         if not found:
             raise AssertionError(
                 "Couldn't find the expected first boot script.")
+
+
+class OsMorphingMinionPoolDeploymentTest(
+        integration_base.MinionPoolTestBase, OsMorphingDeploymentTestBase):
+    """OS morphing deployment using a minion pool for the OS morphing phase."""
+
+    _CREATE_MINION_POOLS = True
+
+    def test_deployment_with_os_morphing(self):
+        self.assertFalse(
+            osmorphing_utils.path_exists_on_device(
+                self._src_device, "usr/bin/jq"),
+            "jq was found on the source device before OS morphing",
+        )
+
+        deployment_kwargs = {
+            "instance_osmorphing_minion_pool_mappings": {
+                self._instance_name: self._pool_id,
+            },
+        }
+        self._execute_transfer_and_deployment(deployment_kwargs)
+
+        self.assertTrue(
+            osmorphing_utils.path_exists_on_device(
+                self._dst_device, "usr/bin/jq"),
+            "jq was not found on the destination device after OS morphing",
+        )
+
+        ctxt = self._get_db_context()
+        pool = db_api.get_minion_pool(
+            ctxt, self._pool_id, include_machines=True)
+        self.assertTrue(
+            pool.minion_machines,
+            "OS morphing pool has no minion machines")
+
+        for machine in pool.minion_machines:
+            self.assertIsNotNone(
+                machine.last_used_at,
+                "OS morphing minion machine %s was never used" % machine.id,
+            )

--- a/coriolis/tests/integration/test_endpoints.py
+++ b/coriolis/tests/integration/test_endpoints.py
@@ -10,6 +10,8 @@ Exercises endpoint-related operations via the Coriolis REST API:
 - get_storage (list and default)
 - get_source_environment_options
 - get_target_environment_options
+- get_destination_minion_pool_options
+- get_inventory_csv
 - endpoint_instances.list and endpoint_instances.get
 """
 
@@ -93,6 +95,19 @@ class EndpointCapabilitiesTest(base.CoriolisIntegrationTestBase):
         self.assertIsInstance(options, list)
         self.assertTrue(
             len(options) > 0, "Expected at least one destination option")
+
+    def test_list_destination_minion_pool_options(self):
+        options = self._client.endpoint_destination_minion_pool_options.list(
+            self._dst_endpoint.id)
+        self.assertIsInstance(options, list)
+        self.assertTrue(
+            len(options) > 0,
+            "Expected at least one destination minion pool option")
+
+    def test_get_inventory_csv(self):
+        csv_content = self._client.endpoints.get_inventory_csv(
+            self._src_endpoint.id, source_environment={})
+        self.assertTrue(csv_content, "Expected non-empty inventory CSV")
 
     def test_list_instances(self):
         instances = self._client.endpoint_instances.list(

--- a/coriolis/tests/integration/test_minion_pools.py
+++ b/coriolis/tests/integration/test_minion_pools.py
@@ -10,7 +10,10 @@ Exercises minion-pool operations via the Coriolis REST API:
   deallocate -> wait for DEALLOCATED -> delete)
 """
 
+import time
+
 from coriolis import constants
+from coriolis.db import api as db_api
 from coriolis.tests.integration import base
 
 
@@ -24,6 +27,24 @@ class MinionPoolLifecycleTest(base.MinionPoolTestBase):
             endpoint_type=self._imp_platform,
             connection_info=self._imp_conn_info,
         )
+
+    def _wait_for_machine_status(self, pool_id, status, timeout=120):
+        """Poll the DB until the pool's single machine reaches *status*."""
+        ctxt = self._get_db_context()
+        deadline = time.monotonic() + timeout
+        machine = None
+
+        while time.monotonic() < deadline:
+            pool = db_api.get_minion_pool(ctxt, pool_id, include_machines=True)
+            machine = pool.minion_machines[0]
+            if machine.allocation_status == status:
+                return machine
+            time.sleep(1)
+
+        self.fail(
+            "Minion pool machine '%s' did not reach status '%s' within %ds "
+            "(last status: %s)"
+            % (pool_id, status, timeout, machine.allocation_status))
 
     def test_minion_pool_crud(self):
         # Create
@@ -46,10 +67,14 @@ class MinionPoolLifecycleTest(base.MinionPoolTestBase):
         self.assertEqual("test-pool", fetched.name)
 
         # Update
-        updated = self._client.minion_pools.update(
-            pool.id, {"notes": "updated notes"})
+        updates = {
+            "notes": "updated notes",
+            "environment_options": self._pool_env,
+        }
+        updated = self._client.minion_pools.update(pool.id, updates)
 
         self.assertEqual("updated notes", updated.notes)
+        self.assertEqual(self._pool_env, updated.environment_options)
 
         # Delete
         self._safe_delete_pool(pool.id)
@@ -71,6 +96,12 @@ class MinionPoolLifecycleTest(base.MinionPoolTestBase):
             final.status,
             "Pool allocation ended in unexpected status '%s'" % final.status,
         )
+
+        # Refresh: healthchecks the allocated machine and returns it to
+        # AVAILABLE.
+        self._client.minion_pools.refresh_minion_pool(pool.id)
+        self._wait_for_machine_status(
+            pool.id, constants.MINION_MACHINE_STATUS_AVAILABLE)
 
         # Deallocate
         self._client.minion_pools.deallocate_minion_pool(pool.id)

--- a/coriolis/tests/integration/test_provider/exp.py
+++ b/coriolis/tests/integration/test_provider/exp.py
@@ -8,6 +8,8 @@ Uses Replicator (via SSH to a Docker data-minion container) to deploy and
 manage the coriolis-replicator service and perform disk replication.
 """
 
+import csv
+import io
 import os
 import uuid
 
@@ -18,6 +20,7 @@ import paramiko
 from coriolis import events
 from coriolis.providers import backup_writers
 from coriolis.providers.base import BaseEndpointInstancesProvider
+from coriolis.providers.base import BaseEndpointInventoryExportProvider
 from coriolis.providers.base import BaseEndpointSourceOptionsProvider
 from coriolis.providers.base import BaseReplicaExportProvider
 from coriolis.providers.base import BaseReplicaExportValidationProvider
@@ -40,6 +43,7 @@ _TEST_NIC = {
 
 class TestExportProvider(
         BaseEndpointInstancesProvider,
+        BaseEndpointInventoryExportProvider,
         BaseEndpointSourceOptionsProvider,
         BaseUpdateSourceReplicaProvider,
         BaseReplicaExportProvider,
@@ -120,6 +124,29 @@ class TestExportProvider(
     def get_instance(self, ctxt, connection_info, source_environment,
                      instance_name):
         return self._instance_info(source_environment)
+
+    # BaseEndpointInventoryExportProvider
+
+    def export_instance_inventory(
+            self, ctxt, connection_info, source_environment):
+        instance = self._instance_info(source_environment)
+        output = io.StringIO()
+
+        writer = csv.writer(output)
+        writer.writerow([
+            "VM ID", "VM Name", "Guest OS", "Num CPUs", "Memory (MB)",
+            "NIC Count",
+        ])
+        writer.writerow([
+            instance["id"],
+            instance["name"],
+            instance["os_type"],
+            instance["num_cpu"],
+            instance["memory_mb"],
+            len(instance["devices"]["nics"]),
+        ])
+
+        return output.getvalue()
 
     def _instance_info(self, source_environment):
         device = source_environment.get("block_device_path", "")

--- a/coriolis/tests/integration/test_provider/imp.py
+++ b/coriolis/tests/integration/test_provider/imp.py
@@ -414,8 +414,12 @@ class TestImportProvider(
         # We must pre-authorize all block devices through the
         # --device-cgroup-rule option, otherwise any device added will be
         # inaccessible ("operation not permitted" error on open).
+        #
+        # Mount the host's /lib/modules tree so that modprobe can
+        # resolve built-in modules.
+        volumes = ["/lib/modules:/lib/modules:ro"]
         result = self._create_minion(
-            "coriolis-pool-minion", connection_info, [],
+            "coriolis-pool-minion", connection_info, [], volumes,
             device_cgroup_rules=["b *:* rwm"])
 
         backup_writer_conn_info = result["backup_writer_connection_info"]
@@ -493,4 +497,19 @@ class TestImportProvider(
     def get_additional_os_morphing_info(
             self, ctxt, connection_info, target_environment,
             instance_deployment_info):
-        return {}
+        devices = list(instance_deployment_info.get("devices", []))
+
+        # lsblk inside the container sees all the host block devices because
+        # Docker containers share the host kernel's sysfs (/sys/block/).
+        # Populate ignore_devices with every host disk except the target
+        # so osmorphing only considers the devices we actually attached.
+        ignore_devices = list(
+            test_utils.get_host_disk_devices() - set(devices)
+        )
+
+        return {
+            "osmorphing_info": {
+                "os_type": instance_deployment_info.get("os_type", "linux"),
+                "ignore_devices": ignore_devices,
+            }
+        }

--- a/coriolis/tests/tasks/test_minion_pool_tasks.py
+++ b/coriolis/tests/tasks/test_minion_pool_tasks.py
@@ -466,6 +466,13 @@ class AttachVolumesToOSMorphingMinionTaskTestCase(
         super(AttachVolumesToOSMorphingMinionTaskTestCase, self).setUp()
         self.task_runner = mp_tasks.AttachVolumesToOSMorphingMinionTask()
 
+    def test__get_volumes_info_from_task_info(self):
+        task_info = {"volumes_info": [{"id": "vol1"}]}
+        result = (
+            mp_tasks.AttachVolumesToOSMorphingMinionTask.
+            _get_volumes_info_from_task_info(task_info))
+        self.assertEqual([{"id": "vol1"}], result)
+
     def test_get_required_task_info_properties(self):
         mock_super_call = mock.MagicMock(return_value=["field1", "field2"])
         with mock.patch.object(
@@ -476,7 +483,9 @@ class AttachVolumesToOSMorphingMinionTaskTestCase(
                 get_required_task_info_properties()
             self.assertEqual(
                 sorted(result),
-                sorted(['field1', 'field2', 'instance_deployment_info']))
+                sorted([
+                    'field1', 'field2', 'volumes_info',
+                    'instance_deployment_info']))
 
     def test_get_returned_task_info_properties(self):
         mock_super_call = mock.MagicMock(return_value=["field1", "field2"])


### PR DESCRIPTION
Adds test for `endpoint_destination_minion_pool_options` index route and `endpoint_inventory` CSV route.

Implement `BaseEndpointInventoryExportProvider` for `TestExportProvider`, so the scheduler can find a worker advertising `PROVIDER_TYPE_ENDPOINT_INVENTORY_EXPORT`, making the `endpoint_inventory.py` index route testable.

Fixes serializer mismatch in `wsgi.py` for `Fault` / `OverLimitFault`, avoiding a potential `KeyError` if the requested content type is not `"application/json"` (e.g.: `endpoint_inventory` CSV endpoint requests the `"text/csv"` content type). Error responses are always JSON.

Include `"environment_options"` in the minion pool update, exercising  `_validate_updated_environment_options`, which the existing notes only update never reached.

Exercises `refresh_minion_pool`'s healthcheck workflow.

Covers the OS morphing step during deployments using minion pools.

Fixes `AttachVolumesToOSMorphingMinionTask` reading the wrong task_info key. `_get_volumes_info_from_task_info` currently hits a `KeyError` by accessing `task_info["instance_deployment_info"]["volumes_info"]`, which starts being populated in its `_run` method, *after* running `super()._run()` (where `_get_volumes_info_from_task_info` is first called). Instead, `_get_volumes_info_from_task_info` should `return task_info["volumes_info"]`. Note that `_BaseAttachVolumesToTransferMinionTask` already returns `task_info["volumes_info"]`.

Updates `TestImportProvider`'s methods related to OS morphing minions. The minions should be able to run `modprobe dm-mod`, which is why `/lib/modules` is mounted in the minions (mirrors `deploy_os_morphing_resources`). `get_additional_os_morphing_info` should return a dict containing `"osmorphing_info"`.