### PR TITLE
[gh-runners] Update apt package lists when running integration tests.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,10 @@ jobs:
         python-version: "3.10"
         architecture: "x64"
 
+    - name: Update apt package lists
+      shell: bash
+      run: sudo apt-get update -y
+
     - name: Install tox
       shell: bash
       run: |


### PR DESCRIPTION
This PR makes sure that the apt package lists are being updated before running integration tests, as otherwise the runner machine may be out of sync with remote apt repositories and return 404 when looking for required packages to install.  