### PR TITLE
Prevent creation of <string>.log

### DIFF
--- a/coriolis/taskflow/runner.py
+++ b/coriolis/taskflow/runner.py
@@ -90,7 +90,8 @@ class TaskFlowRunner(object):
     def _setup_task_process_logging(self, mp_log_q):
         # Setting up logging and cfg, needed since this is a new process
         cfg.CONF(sys.argv[1:], project='coriolis', version="1.0.0")
-        utils.setup_logging()
+        # Spawn children are started via python -c; avoid creating <string>.log
+        utils.setup_logging(disable_file_handlers=True)
 
         # Log events need to be handled in the parent process
         log_root = logging.getLogger(None).logger

--- a/coriolis/tests/taskflow/test_runner.py
+++ b/coriolis/tests/taskflow/test_runner.py
@@ -116,7 +116,8 @@ class TaskFlowRunnerTestCase(test_base.CoriolisBaseTestCase):
         self.runner._setup_task_process_logging(self.mock_mp_log_q)
         mock_conf.assert_called_once_with(sys.argv[1:], project='coriolis',
                                           version='1.0.0')
-        mock_setup_logging.assert_called_once()
+        mock_setup_logging.assert_called_once_with(
+            disable_file_handlers=True)
         mock_get_logger.assert_called_once_with(None)
         mock_queue_handler.assert_called_once_with(self.mock_mp_log_q)
         mock_get_logger.return_value.logger.removeHandler.\

--- a/coriolis/tests/test_utils.py
+++ b/coriolis/tests/test_utils.py
@@ -43,6 +43,17 @@ class UtilsTestCase(test_base.CoriolisBaseTestCase):
         utils.setup_logging()
         mock_setup.assert_called_once_with(utils.CONF, 'coriolis')
 
+    @mock.patch.object(utils.CONF, 'set_override')
+    @mock.patch('oslo_log.log.setup')
+    def test_setup_logging_disable_file_handlers(
+            self, mock_setup, mock_set_override):
+        utils.setup_logging(disable_file_handlers=True)
+        mock_set_override.assert_has_calls([
+            mock.call('log_dir', None),
+            mock.call('log_file', None),
+        ])
+        mock_setup.assert_called_once_with(utils.CONF, 'coriolis')
+
     @mock.patch.object(utils, 'get_exception_details')
     def test_ignore_exceptions(self, mock_get_details):
         mock_get_details.return_value = 'Test exception details'

--- a/coriolis/tests/worker/rpc/test_server.py
+++ b/coriolis/tests/worker/rpc/test_server.py
@@ -1243,7 +1243,8 @@ class WorkerServerEndpointTestCase(test_base.CoriolisBaseTestCase):
         mock_conf.assert_called_once_with(
             mock_get_worker_count_from_args.return_value[1][1:],
             project='coriolis', version='1.0.0')
-        mock_setup_logging.assert_called_once_with()
+        mock_setup_logging.assert_called_once_with(
+            disable_file_handlers=True)
         mock_get_logger.assert_called_once_with(None)
         mock_logger.removeHandler.assert_called_once_with(
             mock.sentinel.handler)

--- a/coriolis/utils.py
+++ b/coriolis/utils.py
@@ -141,7 +141,18 @@ def get_diagnostics_info():
     }
 
 
-def setup_logging():
+def setup_logging(disable_file_handlers=False):
+    """Configure oslo logging for Coriolis.
+
+    :param disable_file_handlers: When True, clear log_dir/log_file so oslo_log
+        does not create a log file. Needed for multiprocessing spawn children,
+        where the binary name resolves to ``<string>`` and would otherwise
+        create an empty ``<string>.log`` under log_dir. Callers that set this
+        typically replace handlers with a QueueHandler afterwards.
+    """
+    if disable_file_handlers:
+        CONF.set_override('log_dir', None)
+        CONF.set_override('log_file', None)
     logging.setup(CONF, 'coriolis')
 
 

--- a/coriolis/worker/rpc/server.py
+++ b/coriolis/worker/rpc/server.py
@@ -666,7 +666,8 @@ def _setup_task_process(mp_log_q):
     # Setting up logging and cfg, needed since this is a new process
     _, args = service.get_worker_count_from_args(sys.argv)
     cfg.CONF(args[1:], project='coriolis', version="1.0.0")
-    utils.setup_logging()
+    # Spawn children are started via python -c; avoid creating <string>.log
+    utils.setup_logging(disable_file_handlers=True)
 
     # Log events need to be handled in the parent process
     log_root = logging.getLogger(None).logger


### PR DESCRIPTION
This PR adds a fix for the creation of `/var/log/coriolis/<string>.log` (empty file) caused by oslo_log deriving the log filename from inspect in multiprocessing spawn children (`python -c`, resulting in `<string>`). File handlers are disabled in those child setup paths and logs still go to the parent via `QueueHandler`.

The only change is adding an option in the `setup_logging` method for `disable_file_handlers` (default value = False).