### PR TITLE
Prevent <string> syslog stream from multiprocessing spawn children

### DIFF
--- a/coriolis/taskflow/runner.py
+++ b/coriolis/taskflow/runner.py
@@ -90,12 +90,13 @@ class TaskFlowRunner(object):
     def _setup_task_process_logging(self, mp_log_q):
         # Setting up logging and cfg, needed since this is a new process
         cfg.CONF(sys.argv[1:], project='coriolis', version="1.0.0")
-        # Spawn children are started via python -c; avoid creating <string>.log
+        # Spawn children are started via python -c;
+        # avoid <string> file/syslog logs
         utils.setup_logging(disable_file_handlers=True)
 
         # Log events need to be handled in the parent process
         log_root = logging.getLogger(None).logger
-        for handler in log_root.handlers:
+        for handler in list(log_root.handlers):
             log_root.removeHandler(handler)
         log_root.addHandler(handlers.QueueHandler(mp_log_q))
 

--- a/coriolis/tests/test_utils.py
+++ b/coriolis/tests/test_utils.py
@@ -52,6 +52,7 @@ class UtilsTestCase(test_base.CoriolisBaseTestCase):
         mock_set_override.assert_has_calls([
             mock.call('log_dir', None),
             mock.call('log_file', None),
+            mock.call('use_syslog', False),
         ])
         mock_setup.assert_called_once_with(utils.CONF, 'coriolis')
 

--- a/coriolis/utils.py
+++ b/coriolis/utils.py
@@ -145,15 +145,18 @@ def get_diagnostics_info():
 def setup_logging(disable_file_handlers=False):
     """Configure oslo logging for Coriolis.
 
-    :param disable_file_handlers: When True, clear log_dir/log_file so oslo_log
-        does not create a log file. Needed for multiprocessing spawn children,
-        where the binary name resolves to ``<string>`` and would otherwise
-        create an empty ``<string>.log`` under log_dir. Callers that set this
-        typically replace handlers with a QueueHandler afterwards.
+    :param disable_file_handlers: When True, clear log_dir/log_file and disable
+        syslog so oslo_log does not create handlers keyed by the process binary
+        name. Needed for multiprocessing spawn children, where that name
+        resolves to ``<string>`` and would otherwise create an empty
+        ``<string>.log`` under log_dir and/or a ``<string>`` syslog stream in
+        coriolis-logger. Callers that set this typically replace handlers with
+        a QueueHandler afterwards.
     """
     if disable_file_handlers:
         CONF.set_override('log_dir', None)
         CONF.set_override('log_file', None)
+        CONF.set_override('use_syslog', False)
     logging.setup(CONF, 'coriolis')
 
 

--- a/coriolis/worker/rpc/server.py
+++ b/coriolis/worker/rpc/server.py
@@ -666,12 +666,12 @@ def _setup_task_process(mp_log_q):
     # Setting up logging and cfg, needed since this is a new process
     _, args = service.get_worker_count_from_args(sys.argv)
     cfg.CONF(args[1:], project='coriolis', version="1.0.0")
-    # Spawn children are started via python -c; avoid creating <string>.log
+    # Spawn children are started via python -c; avoid <string> file/syslog logs
     utils.setup_logging(disable_file_handlers=True)
 
     # Log events need to be handled in the parent process
     log_root = logging.getLogger(None).logger
-    for handler in log_root.handlers:
+    for handler in list(log_root.handlers):
         log_root.removeHandler(handler)
     log_root.addHandler(handlers.QueueHandler(mp_log_q))
 


### PR DESCRIPTION
This is a follow up PR for #492 because oslo_log also uses inspect for the syslog identity in spawn children (`python -c`), which resolves to `<string>`. In order to completely fix the issue, we set the `use_syslog` to `False` there and remove handlers via `list(log_root.handlers)` so none are skipped while mutating the live list before attaching `QueueHandler` (logs still go to the parent).