### PR TITLE
Document `delete_replica_source_snapshots` return value

### DIFF
--- a/coriolis/providers/base.py
+++ b/coriolis/providers/base.py
@@ -969,8 +969,9 @@ class BaseReplicaExportProvider(BaseExportInstanceProvider):
                                    parameters
         :param volumes_info: destination volumes conforming to
                              disk_sync_resources_info_schema.json
+        :returns: the updated volumes info
         """
-        pass
+        return volumes_info
 
     @abc.abstractmethod
     def shutdown_instance(


### PR DESCRIPTION
`delete_replica_source_snapshots` is expected to return the updated volumes info, even if the provider method is a no-op. If nothing is returned, deleting the target replica disks will fail.

As such, we'll document the expected return value.