### PR TITLE
wsman: avoid logging passwords

### DIFF
--- a/coriolis/wsman.py
+++ b/coriolis/wsman.py
@@ -75,8 +75,6 @@ class WSManConnection(object):
         cert_key_pem = connection_info.get("cert_key_pem")
         url = "https://%s:%s/wsman" % (host, port)
 
-        LOG.info("Connection info: %s", str(connection_info))
-
         LOG.info("Waiting for connectivity on host: %(host)s:%(port)s",
                  {"host": host, "port": port})
         utils.wait_for_port_connectivity(host, port)


### PR DESCRIPTION
The WSMAN (WinRM) connection info is expected to contain sensitive data, such as passwords or key certificates.
    
For this reason, it shouldn't be logged. There's a subsequent log message covering the host and port, which should be enough.