### PR TITLE
os-morphing: use grubby for kernel command line arguments

### DIFF
--- a/coriolis/osmorphing/base.py
+++ b/coriolis/osmorphing/base.py
@@ -760,6 +760,10 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
                     "sed -i '/cloud-init=disabled/d' %s" % grub_conf_disabler
                 )
                 self._schedule_grub2_update()
+                # NOTE: BLS entries are not regenerated from
+                # '/etc/default/grub', so the argument must be dropped
+                # from the installed kernels explicitly.
+                self._update_kernel_cmdline_args(args_to_remove=["cloud-init=disabled"])
 
     def _reset_cloud_init_run(self):
         self._exec_cmd_chroot("cloud-init clean --logs")
@@ -951,6 +955,49 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
                 "GRUB_CMDLINE_LINUX", kernel_cmd, config_obj, replace=replace
             )
 
+    def _update_kernel_cmdline_args(self, args_to_add=None, args_to_remove=None):
+        """Updates the kernel command line of all the installed kernels.
+
+        BLS-based distros (RHEL 9/10 and derivatives) keep the command line of
+        every installed kernel in its own '/boot/loader/entries/*.conf', which
+        'grub2-mkconfig' does not regenerate from '/etc/default/grub'.
+
+        :return: True if 'grubby' applied the arguments, False otherwise, in
+            which case the caller must rely on the GRUB config regeneration.
+        """
+        if isinstance(args_to_add, str):
+            args_to_add = [args_to_add]
+        if isinstance(args_to_remove, str):
+            args_to_remove = [args_to_remove]
+        if not args_to_add and not args_to_remove:
+            return False
+
+        # NOTE: the removals are applied first, in a separate 'grubby' call,
+        # so that replacing the value of an existing argument (e.g. changing
+        # the value of a 'console=' argument) always ends up with the new
+        # value.
+        try:
+            for option, args in (
+                ("--remove-args", args_to_remove),
+                ("--args", args_to_add),
+            ):
+                if not args:
+                    continue
+                self._exec_cmd_chroot(
+                    "grubby --update-kernel=ALL %s=%s"
+                    % (option, shlex.quote(" ".join(args)))
+                )
+        except Exception:
+            LOG.warning(
+                "Failed to update the kernel arguments using 'grubby' (it is "
+                "not available on all distros). Falling back to the GRUB "
+                "config regeneration. Error was: %s",
+                utils.get_exception_details(),
+            )
+            return False
+
+        return True
+
     def _get_grub_default_conf(self):
         grub_conf = "/etc/default/grub"
         if self._test_path_chroot(grub_conf):
@@ -1057,6 +1104,11 @@ class BaseLinuxOSMorphingTools(BaseOSMorphingTools):
 
         self._set_grub2_cmdline(config_obj, options)
         self._apply_grub2_config(config_obj, execute_update_grub)
+
+        # NOTE: '/etc/default/grub' is updated above so that the console
+        # settings are preserved for kernels installed later on, while the
+        # already installed ones are updated through 'grubby'.
+        self._update_kernel_cmdline_args(args_to_add=options)
 
     def _add_net_udev_rules(self, net_ifaces_info):
         coriolis_udev_rules_file = "etc/udev/rules.d/99-coriolis-net.rules"

--- a/coriolis/tests/osmorphing/test_base.py
+++ b/coriolis/tests/osmorphing/test_base.py
@@ -1012,6 +1012,7 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
         ((False, False, True), 'GRUB_CMDLINE_LINUX="console=ttyS0"', [], False),
     )
     @ddt.unpack
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, "_update_kernel_cmdline_args")
     @mock.patch.object(base.BaseLinuxOSMorphingTools, "_read_file_sudo")
     @mock.patch.object(base.BaseLinuxOSMorphingTools, "_schedule_grub2_update")
     @mock.patch.object(base.BaseLinuxOSMorphingTools, "_exec_cmd_chroot")
@@ -1026,6 +1027,7 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
         mock__exec_cmd_chroot,
         mock__schedule_grub2_update,
         mock__read_file_sudo,
+        mock__update_kernel_cmdline_args,
     ):
         mock__test_path.side_effect = test_path_results
         mock__read_file_sudo.return_value = grub_defaults_contents
@@ -1036,8 +1038,13 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
         self.assertEqual(called_cmds, expected_cmds)
         if updates_grub:
             mock__schedule_grub2_update.assert_called_once()
+            # the argument must be dropped from the installed kernels too
+            mock__update_kernel_cmdline_args.assert_called_once_with(
+                args_to_remove=["cloud-init=disabled"]
+            )
         else:
             mock__schedule_grub2_update.assert_not_called()
+            mock__update_kernel_cmdline_args.assert_not_called()
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, "_exec_cmd_chroot")
     def test__reset_cloud_init_run(self, mock__exec_cmd_chroot):
@@ -1534,6 +1541,93 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
         self.os_morphing_tools._set_grub2_cmdline(config_obj, options, clobber=False)
         mock_set_grub_value.assert_not_called()
 
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_add(self, mock_exec_cmd_chroot):
+        result = self.os_morphing_tools._update_kernel_cmdline_args(
+            args_to_add=['console=tty0', 'console=ttyS0']
+        )
+
+        self.assertTrue(result)
+        mock_exec_cmd_chroot.assert_called_once_with(
+            "grubby --update-kernel=ALL --args='console=tty0 console=ttyS0'"
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_string_arg(self, mock_exec_cmd_chroot):
+        result = self.os_morphing_tools._update_kernel_cmdline_args(
+            args_to_add='console=ttyS0'
+        )
+
+        self.assertTrue(result)
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'grubby --update-kernel=ALL --args=console=ttyS0'
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_remove(self, mock_exec_cmd_chroot):
+        result = self.os_morphing_tools._update_kernel_cmdline_args(
+            args_to_remove=['cloud-init=disabled']
+        )
+
+        self.assertTrue(result)
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'grubby --update-kernel=ALL --remove-args=cloud-init=disabled'
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_add_and_remove(self, mock_exec_cmd_chroot):
+        result = self.os_morphing_tools._update_kernel_cmdline_args(
+            args_to_add=['console=ttyS0'], args_to_remove=['console=ttyS1']
+        )
+
+        self.assertTrue(result)
+        # the removal must be applied before the addition
+        self.assertEqual(
+            [
+                mock.call('grubby --update-kernel=ALL --remove-args=console=ttyS1'),
+                mock.call('grubby --update-kernel=ALL --args=console=ttyS0'),
+            ],
+            mock_exec_cmd_chroot.call_args_list,
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_no_args(self, mock_exec_cmd_chroot):
+        result = self.os_morphing_tools._update_kernel_cmdline_args()
+
+        self.assertFalse(result)
+        mock_exec_cmd_chroot.assert_not_called()
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_no_grubby(self, mock_exec_cmd_chroot):
+        # distros without 'grubby' (e.g. Debian/Ubuntu) must fall back to the
+        # GRUB config regeneration instead of erroring out
+        mock_exec_cmd_chroot.side_effect = CoriolisTestException(
+            'grubby: command not found'
+        )
+
+        result = self.os_morphing_tools._update_kernel_cmdline_args(
+            args_to_add=['console=ttyS0']
+        )
+
+        self.assertFalse(result)
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'grubby --update-kernel=ALL --args=console=ttyS0'
+        )
+
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_exec_cmd_chroot')
+    def test__update_kernel_cmdline_args_grubby_fails(self, mock_exec_cmd_chroot):
+        mock_exec_cmd_chroot.side_effect = CoriolisTestException('err')
+
+        result = self.os_morphing_tools._update_kernel_cmdline_args(
+            args_to_add=['console=ttyS0'], args_to_remove=['console=ttyS1']
+        )
+
+        self.assertFalse(result)
+        # the failure of the first 'grubby' call must not be retried
+        mock_exec_cmd_chroot.assert_called_once_with(
+            'grubby --update-kernel=ALL --remove-args=console=ttyS1'
+        )
+
     @mock.patch.object(
         base.BaseLinuxOSMorphingTools,
         '_get_grub_default_conf',
@@ -1792,6 +1886,7 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
             consoles='invalid_consoles',
         )
 
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_update_kernel_cmdline_args')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_apply_grub2_config')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_set_grub2_cmdline')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
@@ -1802,6 +1897,7 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
         mock_set_grub_value,
         mock_set_grub2_cmdline,
         mock_apply_grub2_config,
+        mock_update_kernel_cmdline_args,
     ):
         consoles = ['tty0', 'ttyS0']
         speed = 9600
@@ -1825,7 +1921,13 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
             config_obj, ['console=tty0', 'console=ttyS0']
         )
         mock_apply_grub2_config.assert_called_once_with(config_obj, False)
+        # the console arguments must also be applied to the already
+        # installed kernels, and not just to '/etc/default/grub'
+        mock_update_kernel_cmdline_args.assert_called_once_with(
+            args_to_add=['console=tty0', 'console=ttyS0']
+        )
 
+    @mock.patch.object(base.BaseLinuxOSMorphingTools, '_update_kernel_cmdline_args')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_apply_grub2_config')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_set_grub2_cmdline')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, 'set_grub_value')
@@ -1836,6 +1938,7 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
         mock_set_grub_value,
         mock_set_grub2_cmdline,
         mock_apply_grub2_config,
+        mock_update_kernel_cmdline_args,
     ):
         grub_conf = '/etc/default/grub'
 
@@ -1856,6 +1959,9 @@ class BaseLinuxOSMorphingToolsTestBase(test_base.CoriolisBaseTestCase):
             config_obj, ['console=tty0', 'console=ttyS0']
         )
         mock_apply_grub2_config.assert_called_once_with(config_obj, True)
+        mock_update_kernel_cmdline_args.assert_called_once_with(
+            args_to_add=['console=tty0', 'console=ttyS0']
+        )
 
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_test_path')
     @mock.patch.object(base.BaseLinuxOSMorphingTools, '_write_file_sudo')


### PR DESCRIPTION
## Problem

Setting the console kernel options has no effect on distros which use the Boot Loader Specification (BLS), such as RHEL 10 and its derivatives, which breaks the text console for VMs on platforms such as LXD.

BLS-based distros keep the kernel command line of every installed kernel in its own `/boot/loader/entries/*.conf` snippet, and `grub2-mkconfig` does not regenerate those from `/etc/default/grub`. Unlike RHEL 8, where the BLS entries reference a shared `$kernelopts` variable, RHEL 10 manages the options per entry, so updating `/etc/default/grub` and regenerating the GRUB config only affects kernels installed afterwards.

## Fix

Adds `_update_kernel_cmdline_args()` to `BaseLinuxOSMorphingTools`, which uses `grubby --update-kernel=ALL --args=/--remove-args=` to update the command line of all the installed kernels. It is called from:

* `_set_grub2_console_settings()`, after the console options are written to `/etc/default/grub`;
* `_ensure_cloud_init_not_disabled()`, to drop `cloud-init=disabled` from the installed kernels.

`/etc/default/grub` is still updated and the GRUB config is still regenerated, since those remain responsible for kernels installed later on and for the rest of the GRUB configuration. The `grubby` call is an addition to that path, not a replacement for it.

Removals are issued before additions, in a separate `grubby` call, so that replacing the value of an existing argument (e.g. `console=`) always ends up with the new value.

## Compatibility

The behaviour is not gated on the distro or its version: `grubby` is used wherever it works, and it is a no-op-safe addition on non-BLS GRUB2 setups. On distros which do not ship `grubby` (e.g. Debian and Ubuntu) the call fails, is logged, and the GRUB config regeneration is relied upon alone, which is the current behaviour.

## Tests

`coriolis/tests/osmorphing/test_base.py`:

* additions, removals, combined add/remove ordering, and string arguments;
* no-op when no arguments are passed;
* fallback when `grubby` is missing or fails;
* `_set_grub2_console_settings()` and `_ensure_cloud_init_not_disabled()` pass the expected arguments.

Ran `ruff format --diff`, `ruff check`, `flake8` (all clean) and the OSMorphing unit tests (661 tests, OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)