### PR TITLE
osmorphing minion pools: use the correct volumes

### DIFF
--- a/coriolis/tasks/minion_pool_tasks.py
+++ b/coriolis/tasks/minion_pool_tasks.py
@@ -632,6 +632,11 @@ class AttachVolumesToOSMorphingMinionTask(_BaseVolumesMinionMachineAttachmentTas
     @classmethod
     def _get_volumes_info_from_task_info(cls, task_info):
         # Similar to _BaseAttachVolumesToTransferMinionTask.
+        if "volumes_info" in task_info["instance_deployment_info"]:
+            # Use the updated volumes info reported by the provider.
+            # If volume cloning is used, those won't be the original volumes.
+            return task_info["instance_deployment_info"]["volumes_info"]
+        # The provider didn't include volumes info, use the original list.
         return task_info["volumes_info"]
 
     @classmethod

--- a/coriolis/tests/tasks/test_minion_pool_tasks.py
+++ b/coriolis/tests/tasks/test_minion_pool_tasks.py
@@ -505,7 +505,7 @@ class AttachVolumesToOSMorphingMinionTaskTestCase(test_base.CoriolisBaseTestCase
         self.task_runner = mp_tasks.AttachVolumesToOSMorphingMinionTask()
 
     def test__get_volumes_info_from_task_info(self):
-        task_info = {"volumes_info": [{"id": "vol1"}]}
+        task_info = {"instance_deployment_info": {"volumes_info": [{"id": "vol1"}]}}
         result = mp_tasks.AttachVolumesToOSMorphingMinionTask._get_volumes_info_from_task_info(
             task_info
         )


### PR DESCRIPTION
We're attaching the original `volumes_info` to osmorphing minions instead of the volumes returned through `instance_deployment_info` by the `deploy_replica_target_resources` provider method.

This breaks disk clones since we're writing to the original transfer disk instead of the disk clone. Furthermore, we're modifying the list of volumes from `instance_deployment_info` after attaching the minion volumes.

https://github.com/cloudbase/coriolis/blob/1c7bf332545826b0c79a5c1efa14b8ce905f0646/coriolis/tasks/minion_pool_tasks.py#L683-L687

Because of that, we're deleting the original volume instead of the clone if osmorphing fails.

The fix is simple: get the osmorphing minion pools to use the volumes from `instance_deployment_info` instead of the original ones.