### PR TITLE
Fix `resolv.conf` not restored before unmount

### DIFF
--- a/coriolis/osmorphing/osmount/base.py
+++ b/coriolis/osmorphing/osmount/base.py
@@ -739,6 +739,9 @@ class BaseLinuxOSMountTools(luks_mixin.LinuxLUKSMixin, BaseSSHOSMountTools):
         return os_root_dir, os_root_device
 
     def dismount_os(self, root_dir):
+        # Flush dirty pages to replica volumes before unmount.
+        # Later volume detach would otherwise drop in-memory writes.
+        self._exec_cmd("sudo sync")
         self._exec_cmd('sudo fuser --kill --mount %s || true' % root_dir)
         # NOTE: the binds are made private as they are made, but a mount can
         # still propagate in before that happens, and chroots mounted by an

--- a/coriolis/tests/osmorphing/osmount/test_base.py
+++ b/coriolis/tests/osmorphing/osmount/test_base.py
@@ -1309,6 +1309,7 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
 
         mock_exec_cmd.assert_has_calls(
             [
+                mock.call("sudo sync"),
                 mock.call("sudo fuser --kill --mount /mnt/root_dir || true"),
                 mock.call(
                     "mountpoint -q /mnt/root_dir && sudo mount --make-rprivate "
@@ -1349,14 +1350,19 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
         self.base_os_mount_tools.dismount_os("/mnt/root_dir")
 
         issued = [call.args[0] for call in mock_exec_cmd.call_args_list]
+        sync_cmd = "sudo sync"
+        fuser_cmd = "sudo fuser --kill --mount /mnt/root_dir || true"
         rprivate_cmd = (
             "mountpoint -q /mnt/root_dir && sudo mount --make-rprivate "
             "/mnt/root_dir || true"
         )
         umount_cmd = "mountpoint -q /mnt/root_dir && sudo umount -R /mnt/root_dir"
 
+        self.assertEqual(issued[0], sync_cmd)
+        self.assertIn(fuser_cmd, issued)
         self.assertIn(rprivate_cmd, issued)
         self.assertIn(umount_cmd, issued)
+        self.assertLess(issued.index(sync_cmd), issued.index(fuser_cmd))
         self.assertLess(issued.index(rprivate_cmd), issued.index(umount_cmd))
 
     @mock.patch.object(base.utils, 'get_url_with_credentials')


### PR DESCRIPTION
We'll do a sync before dismounting the OS partition in order to ensure that all the changes made by Coriolis are flushed to disk.