### PR TITLE
lvm: fix reusing minion pool for os morphing and disk replication

### DIFF
--- a/coriolis/providers/backup_writers.py
+++ b/coriolis/providers/backup_writers.py
@@ -121,14 +121,18 @@ def _disable_lvm_metad_udev_rule(ssh):
     detected with lvm partitions (after a transfer is complete). During normal
     migrations with multiple replications, these services need to be disabled,
     therefore we make it impossible for the minion OS to create them.
+
+    The lvm2 initramfs hook must be deleted as well, otherwise the initrd
+    cannot be regenerated when installing packages.
     """
-    rule_paths = [
+    removed_paths = [
         "/lib/udev/rules.d/69-lvm-metad.rules",
         "/lib/udev/rules.d/69-dm-lvm.rules",
         "/lib/udev/rules.d/69-lvm.rules",
         "/lib/udev/rules.d/56-lvm.rules",
+        "/usr/share/initramfs-tools/hooks/lvm2",
     ]
-    for path in rule_paths:
+    for path in removed_paths:
         if utils.test_ssh_path(ssh, path):
             utils.exec_ssh_cmd(ssh, "sudo rm %s" % path, get_pty=False)
 


### PR DESCRIPTION
We're disabling lvm udev rules as part of the backup writer setup in order to prevent the migrated volumes from being automatically mounted on the replicator vm.

The problem is that we're leaving behind an initrd lvm hook that will error out if the lvm udev rules are missing:

```
update-initramfs: Generating /boot/initrd.img-6.8.0-138-generic
E: /usr/share/initramfs-tools/hooks/lvm2 failed with return 1.

...
for rules in 56-lvm.rules 69-lvm.rules; do
	if   [ -e /etc/udev/rules.d/$rules ]; then
		cp -p /etc/udev/rules.d/$rules $DESTDIR/lib/udev/rules.d/
	elif [ -e /lib/udev/rules.d/$rules ]; then
		cp -p /lib/udev/rules.d/$rules $DESTDIR/lib/udev/rules.d/
	else
		exit 1
	fi
done
...
```

This prevents other packages from getting installed, breaking the os morphing initialization.

We'll solve it by removing the leftover lvm hook.