### PR TITLE
osmount: avoid stale propagated mounts

### DIFF
--- a/coriolis/osmorphing/osmount/base.py
+++ b/coriolis/osmorphing/osmount/base.py
@@ -655,6 +655,15 @@ class BaseLinuxOSMountTools(luks_mixin.LinuxLUKSMixin, BaseSSHOSMountTools):
         return os_root_dir, os_root_device
 
     def mount_os(self):
+        # Prevent Coriolis mounts from being propagated to other namespaces
+        # belonging to Systemd services. These would be leaked when running
+        # "unmount -R" in this namespace, being especially troublesome if the
+        # minion gets reused. Stale mounts can prevent the FS from being
+        # remounted (e.g. if os-morphing gets retried).
+        #
+        # The other "--make-(r)private" calls may no longer be required.
+        self._exec_cmd("sudo mount --make-rprivate /")
+
         dev_paths = []
         mounted_devs = self._get_mounted_devices()
 

--- a/coriolis/tests/osmorphing/osmount/test_base.py
+++ b/coriolis/tests/osmorphing/osmount/test_base.py
@@ -1190,6 +1190,7 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
         mock_find_dev_with_contents.return_value = "/dev/sdb1"
         mock_exec_cmd.side_effect = [
             "",
+            "",
             "/dev/sda1",
             "",
             "/dev/sdb1",
@@ -1211,6 +1212,7 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
 
         mock_exec_cmd.assert_has_calls(
             [
+                mock.call('sudo mount --make-rprivate /'),
                 mock.call('sudo partx -v -a /dev/sda || true'),
                 mock.call('sudo ls -1 /dev/sda*'),
                 mock.call('sudo partx -v -a /dev/sdb || true'),
@@ -1275,6 +1277,7 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
         mock_get_mounted_devices.return_value = ["/dev/sda1"]
         mock_exec_cmd.side_effect = [
             "",
+            "",
             "xfs\n",
             "",
             "xfs\n",
@@ -1294,6 +1297,7 @@ class BaseLinuxOSMountToolsTestCase(test_base.CoriolisBaseTestCase):
 
         mock_exec_cmd.assert_has_calls(
             [
+                mock.call('sudo mount --make-rprivate /'),
                 mock.call('sudo partx -v -a /dev/sda || true'),
                 mock.call('sudo ls -1 /dev/sda*'),
                 mock.call('sudo partx -v -a /dev/sdb || true'),


### PR DESCRIPTION
We'll need to prevent Coriolis mounts from being propagated to other namespaces belonging to Systemd services.

These would be leaked when running "unmount -R" in this namespace, being especially troublesome if the
minion gets reused. Stale mounts can prevent the FS from being remounted (e.g. if os-morphing gets retried).