### PR TITLE
Add fqdn to export info schema, use short name as hostname

### DIFF
--- a/coriolis/schemas/vm_export_info_schema.json
+++ b/coriolis/schemas/vm_export_info_schema.json
@@ -26,6 +26,10 @@
       "type": "string",
       "description": "Guest hostname of the VM."
     },
+    "fqdn": {
+      "type": "string",
+      "description": "Guest fully-qualified domain name of the VM."
+    },
     "dynamic_memory_enabled": {
       "type": "boolean",
       "description": "Indicates whether not the VM's physical memory was allocated dynamically."

--- a/coriolis/tasks/replica_tasks.py
+++ b/coriolis/tasks/replica_tasks.py
@@ -163,6 +163,10 @@ def _preserve_hostname_info(old_export_info, new_export_info):
     new_hostname = new_export_info.get("hostname", "")
     if not new_hostname:
         new_export_info['hostname'] = old_hostname
+    old_fqdn = old_export_info.get("fqdn", "")
+    new_fqdn = new_export_info.get("fqdn", "")
+    if not new_fqdn:
+        new_export_info['fqdn'] = old_fqdn
 
 
 def _update_export_info(old_export_info, result_export_info):

--- a/coriolis/tests/tasks/data/test_hostname_update.yml
+++ b/coriolis/tests/tasks/data/test_hostname_update.yml
@@ -3,26 +3,35 @@
   new_export_info: {}
   expected_export_info:
     hostname: ""
+    fqdn: ""
 
 # Hostname in old info
 - old_export_info:
-    hostname: old.host.name
+    hostname: old-host
+    fqdn: old-host.example.com
   new_export_info: {}
   expected_export_info:
-    hostname: old.host.name
+    hostname: old-host
+    fqdn: old-host.example.com
 
 # Hostname in new info only
 - old_export_info:
     hostname: ""
+    fqdn: ""
   new_export_info:
-    hostname: "new.host.name"
+    hostname: "new-host"
+    fqdn: "new-host.example.com"
   expected_export_info:
-    hostname: "new.host.name"
+    hostname: "new-host"
+    fqdn: "new-host.example.com"
 
 # Hostname update from old to new
 - old_export_info:
-    hostname: "old.host.name"
+    hostname: "old-host"
+    fqdn: "old-host.example.com"
   new_export_info:
-    hostname: "new.host.name"
+    hostname: "new-host"
+    fqdn: "new-host.example.com"
   expected_export_info:
-    hostname: "new.host.name"
+    hostname: "new-host"
+    fqdn: "new-host.example.com"


### PR DESCRIPTION
Currently VMware exports the FQDN as hostname, and Proxmox expects the short name.
The instance name is hardcoded into the cloud-init drive for cloudbase-init.
Export the short name as hostname and the FQDN as fqdn.