### PR TITLE
Update _raise_response_error to raise a generic exception

### DIFF
--- a/coriolis/licensing/client.py
+++ b/coriolis/licensing/client.py
@@ -84,7 +84,9 @@ class LicensingClient(object):
                 utils.get_exception_details(),
             )
         if error and all([x in error for x in ['code', 'message']]):
-            raise exception.Conflict(message=error['message'], code=int(error['code']))
+            exc = exception.LicensingException(message=error['message'])
+            exc.code = int(error['code'])
+            raise exc
         else:
             resp.raise_for_status()
 

--- a/coriolis/tests/licensing/test_client.py
+++ b/coriolis/tests/licensing/test_client.py
@@ -124,6 +124,23 @@ class LicensingClientTestCase(test_base.CoriolisBaseTestCase):
 
         mock_response.raise_for_status.assert_not_called()
 
+    def test_raise_response_error_forbidden(self):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            'error': {
+                'code': 403,
+                'message': 'refreshing fulfilled Reservation is forbidden',
+            }
+        }
+
+        exc = self.assertRaises(
+            exception.LicensingException,
+            self.client._raise_response_error,
+            mock_response,
+        )
+        self.assertEqual(403, exc.code)
+        mock_response.raise_for_status.assert_not_called()
+
     def test_raise_response_error_json_exception(self):
         mock_response = mock.Mock()
         mock_response.json.side_effect = KeyboardInterrupt()


### PR DESCRIPTION
Previously the _raise_response_error was returning a Conflict exception that had the code 409. This created a bug, so that if the licence was supposed to return a 403 Not Authorized, the exception code was still 409, causing an issue.

This commit changes the exception.Conflict to a generic exception, preserving the exception code received, rather than using 409 for all.